### PR TITLE
Skip slow data migration tests

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -279,10 +279,13 @@ class BreadcrumbMixin(models.Model):
             'service_name': self.service_name_value,
             'slug': self.slug,
         }
-        for lang in modeltranslation_settings.AVAILABLE_LANGUAGES:
-            field_name = build_localized_fieldname('breadcrumbs_label', lang)
-            value = getattr(self, field_name, '')
-            defaults[build_localized_fieldname('label', lang)] = value
+        if 'breadcrumb_label' in self.get_translatable_fields():
+            for lang in modeltranslation_settings.AVAILABLE_LANGUAGES:
+                localizer = partial(build_localized_fieldname, lang=lang)
+                field_name = localizer('breadcrumbs_label')
+                defaults[localizer('label')] = getattr(self, field_name, '')
+        else:
+            defaults['label'] = self.breadcrumbs_label
         self.breadcrumb.update_or_create(defaults=defaults)
 
 

--- a/core/tests/test_migrations.py
+++ b/core/tests/test_migrations.py
@@ -4,7 +4,7 @@ from wagtail_factories import PageFactory
 from modeltranslation.utils import build_localized_fieldname
 
 
-@pytest.mark.skip(rason='slow')
+@pytest.mark.skip(reason='slow')
 @pytest.mark.django_db
 def test_update_url_path(migration, settings):
     migration.before([('core', '0005_auto_20180423_1803')])

--- a/core/tests/test_migrations.py
+++ b/core/tests/test_migrations.py
@@ -4,6 +4,7 @@ from wagtail_factories import PageFactory
 from modeltranslation.utils import build_localized_fieldname
 
 
+@pytest.mark.skip(rason='slow')
 @pytest.mark.django_db
 def test_update_url_path(migration, settings):
     migration.before([('core', '0005_auto_20180423_1803')])

--- a/export_readiness/tests/factories.py
+++ b/export_readiness/tests/factories.py
@@ -46,3 +46,21 @@ class PerformanceDashboardNotesPageFactory(wagtail_factories.PageFactory):
     slug_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
     title_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
     parent = None
+
+
+class GetFinancePageFactory(wagtail_factories.PageFactory):
+
+    class Meta:
+        model = models.GetFinancePage
+
+    breadcrumbs_label = factory.fuzzy.FuzzyText(length=10)
+    banner_content = factory.fuzzy.FuzzyText(length=10)
+    section_one_content = factory.fuzzy.FuzzyText(length=10)
+    section_two_content = factory.fuzzy.FuzzyText(length=10)
+    video_embed = factory.fuzzy.FuzzyText(length=10)
+    section_three_content = factory.fuzzy.FuzzyText(length=10)
+    call_to_action_text = factory.fuzzy.FuzzyText(length=10)
+    call_to_action_url = factory.fuzzy.FuzzyText(length=10)
+    slug_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    title_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    parent = None

--- a/export_readiness/tests/test_models.py
+++ b/export_readiness/tests/test_models.py
@@ -1,35 +1,41 @@
 import pytest
 
-from export_readiness import models as exred_models
-from find_a_supplier import models as fas_models
+import find_a_supplier.models
+from export_readiness import models
+from export_readiness.tests import factories
 
 
 def test_app_models():
-    assert exred_models.ExportReadinessApp.allowed_subpage_models() == [
-        exred_models.ExportReadinessApp,
-        exred_models.TermsAndConditionsPage,
-        exred_models.PrivacyAndCookiesPage,
-        exred_models.GetFinancePage,
-        exred_models.PerformanceDashboardPage,
-        exred_models.PerformanceDashboardNotesPage,
+    assert models.ExportReadinessApp.allowed_subpage_models() == [
+        models.ExportReadinessApp,
+        models.TermsAndConditionsPage,
+        models.PrivacyAndCookiesPage,
+        models.GetFinancePage,
+        models.PerformanceDashboardPage,
+        models.PerformanceDashboardNotesPage,
     ]
 
 
 @pytest.mark.parametrize('model', [
-    exred_models.ExportReadinessApp,
-    fas_models.FindASupplierApp,
-    ]
-)
+    models.ExportReadinessApp,
+    find_a_supplier.models.FindASupplierApp,
+])
 def test_app_required_translatable_fields(model):
     assert model.get_required_translatable_fields() == []
 
 
 @pytest.mark.django_db
 def test_set_slug():
-    instance = exred_models.ExportReadinessApp.objects.create(
+    instance = models.ExportReadinessApp.objects.create(
         title_en_gb='the app',
         depth=2,
         path='/thing',
     )
 
     assert instance.slug_en_gb == 'the-app'
+
+
+@pytest.mark.django_db
+def test_get_finance_breadcrumbs():
+    page = factories.GetFinancePageFactory.create()
+    assert page.breadcrumb.first().label == page.breadcrumbs_label

--- a/find_a_supplier/tests/test_migrations.py
+++ b/find_a_supplier/tests/test_migrations.py
@@ -3,7 +3,7 @@ import pytest
 from find_a_supplier.tests import factories
 
 
-@pytest.mark.skip(rason='slow')
+@pytest.mark.skip(reason='slow')
 @pytest.mark.django_db
 def test_populate_breadcrumb(migration, settings):
     page = factories.IndustryContactPageFactory.create(

--- a/find_a_supplier/tests/test_migrations.py
+++ b/find_a_supplier/tests/test_migrations.py
@@ -3,6 +3,7 @@ import pytest
 from find_a_supplier.tests import factories
 
 
+@pytest.mark.skip(rason='slow')
 @pytest.mark.django_db
 def test_populate_breadcrumb(migration, settings):
     page = factories.IndustryContactPageFactory.create(

--- a/invest/tests/test_migrations.py
+++ b/invest/tests/test_migrations.py
@@ -3,6 +3,7 @@ import pytest
 from invest.tests import factories
 
 
+@pytest.mark.skip(rason='slow')
 @pytest.mark.django_db
 def test_populate_historic_slug_service_name(migration, settings):
     page = factories.InfoPageFactory.create()

--- a/invest/tests/test_migrations.py
+++ b/invest/tests/test_migrations.py
@@ -3,7 +3,7 @@ import pytest
 from invest.tests import factories
 
 
-@pytest.mark.skip(rason='slow')
+@pytest.mark.skip(reason='slow')
 @pytest.mark.django_db
 def test_populate_historic_slug_service_name(migration, settings):
     page = factories.InfoPageFactory.create()


### PR DESCRIPTION
the data migration tests are slow

until we determine why, we skip them.

with these three tests active: 10 mins
with these three tests skipped: 5 mins