### PR TITLE
Ensure translations of a page are cached to same redis node

### DIFF
--- a/core/cache.py
+++ b/core/cache.py
@@ -27,7 +27,11 @@ class PageCache:
         params = {'service_name': service_name}
         if language_code:
             params['lang'] = language_code
-        return url + '?' + urlencode(params)
+        # using the page slug as a redis hash tag ensures the keys related to
+        # the same page in the same node, preventing delete_many from failing
+        # because the keys could be stored across different nodes
+        node_prefix = f'{{slug}}'
+        return node_prefix + url + '?' + urlencode(params)
 
     @classmethod
     def set(cls, slug, service_name, contents, language_code=None):

--- a/core/tests/test_cache.py
+++ b/core/tests/test_cache.py
@@ -32,7 +32,7 @@ def test_page_cache_build_keys(slug, service_name, language_code, expected):
     key = cache.PageCache.build_key(
         slug=slug, service_name=service_name, language_code=language_code
     )
-    assert key == '/api/pages/lookup-by-slug' + expected
+    assert key == f'{{slug}}/api/pages/lookup-by-slug' + expected
 
 
 def test_page_cache_get_set_delete():


### PR DESCRIPTION
fix delete_many not working because the keys are across multiple nodes

by prefixing with {the-slug} we ensure all keys related to the same page are cached on the same node

https://redis.io/topics/cluster-spec#keys-hash-tags