### PR TITLE
CMD-837 editors and moderators should only see pages from their branch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,11 +15,6 @@ from django.db.migrations.executor import MigrationExecutor
 
 from conf import settings
 from find_a_supplier.tests.factories import IndustryPageFactory
-from users.tests.factories import (
-    BranchEditorAndModeratorFactory,
-    BranchEditorFactory,
-    BranchModeratorFactory,
-)
 
 
 @pytest.fixture
@@ -161,18 +156,3 @@ def django_db_setup(django_db_blocker):
 
         for connection in db.connections.all():
             connection.close()
-
-
-@pytest.fixture
-def branch_editor_factory(root_page):
-    return BranchEditorFactory()
-
-
-@pytest.fixture
-def branch_moderator_factory():
-    return BranchModeratorFactory()
-
-
-@pytest.fixture
-def branch_editor_moderator_factory(root_page):
-    return BranchEditorAndModeratorFactory()

--- a/conftest.py
+++ b/conftest.py
@@ -47,6 +47,15 @@ def root_page():
 
 
 @pytest.fixture
+def distinct_root_pages():
+    Page.objects.all().delete()
+    return (
+        wagtail_factories.PageFactory(parent=None, title='root page 1'),
+        wagtail_factories.PageFactory(parent=None, title='root page 2'),
+    )
+
+
+@pytest.fixture
 def untranslated_page(root_page):
     return IndustryPageFactory(
         parent=root_page,
@@ -306,7 +315,7 @@ def setup_branch_with_editor_and_moderator(
     editor_password = editor_password or 'test'
     editor.set_password(editor_password)
     editor.save()
-    
+
     moderator = UserFactory(
         is_superuser=moderator_is_superuser,
         is_staff=moderator_is_staff,

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 from wagtail.images.models import Image
 from wagtail.core.models import Page
-import wagtail_factories
 
 from django.core.cache import cache
 from django.core.files.storage import default_storage
@@ -25,17 +24,10 @@ from users.tests.factories import (
 
 @pytest.fixture
 def root_page():
-    Page.objects.all().delete()
-    return wagtail_factories.PageFactory(parent=None)
-
-
-@pytest.fixture
-def distinct_root_pages():
-    Page.objects.all().delete()
-    return (
-        wagtail_factories.PageFactory(parent=None, title='root page 1'),
-        wagtail_factories.PageFactory(parent=None, title='root page 2'),
-    )
+    """
+    On start Wagtail provides one page with ID=1 and it's called "Root page"
+    """
+    return Page.objects.get(pk=1)
 
 
 @pytest.fixture

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -31,6 +31,13 @@ def test_slugs_are_not_unique_across_services(root_page):
 
 @pytest.mark.django_db
 def test_delete_same_slug_different_services(root_page):
+    """
+    Deleting a page results in ancestor pages being re-saved.
+    Thus ancestor page (root_page) has to have title & title_en_gb.
+    """
+    root_page.title = 'ancestor page has to have a title'
+    root_page.title_en_gb = 'ancestor page has to have a title'
+    root_page.save()
     page_one = IndustryPageFactory(slug='foo', parent=root_page)
     page_two = SectorPageFactory(slug='foo', parent=root_page)
     assert page_one.slug == 'foo'

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -1,12 +1,32 @@
+from collections import namedtuple
+
 import factory
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from wagtail.core.models import GroupPagePermission
+from django.contrib.auth.models import Group, Permission
+from django.test import Client
+from wagtail.core.models import GroupPagePermission, PAGE_PERMISSION_TYPES
 
-from export_readiness.tests.factories import ArticleListingPageFactory
-
+from export_readiness.tests.factories import (
+    ArticleListingPageFactory,
+    ArticlePageFactory,
+)
 
 User = get_user_model()
+Branch = namedtuple(
+    'Branch', ['listing', 'article', 'group', 'user', 'client']
+)
+BranchEditorAndModerator = namedtuple(
+    'BranchEditorAndModerator', [
+        'listing',
+        'article',
+        'editors',
+        'editor',
+        'editor_client',
+        'moderators',
+        'moderator',
+        'moderator_client'
+    ]
+)
 
 
 class GroupFactory(factory.django.DjangoModelFactory):
@@ -45,3 +65,147 @@ class UserFactory(factory.django.DjangoModelFactory):
             # A list of groups were passed in, use them
             for group in extracted:
                 self.groups.add(group)
+
+
+def create_listing_with_article_and_group_with_user_and_client(
+        root_page,
+        *,
+        permissions=[],
+        password='test',
+        is_superuser=False,
+        is_staff=False
+):
+    """Returns a listing page with a child page, user group, user & client.
+
+    For Wagtail permission model check:
+    http://docs.wagtail.io/en/v2.0/topics/permissions.html#page-permissions
+    """
+    # ensure that only permissions supported by Wagtail are used
+    available_permissions = [p for p, _, _ in PAGE_PERMISSION_TYPES]
+    assert not (set(permissions) - set(available_permissions))
+
+    listing_page = ArticleListingPageFactory(parent=root_page)
+    article_page = ArticlePageFactory(parent=listing_page)
+
+    group = GroupFactory()
+    group.permissions.add(Permission.objects.get(codename='access_admin'))
+
+    for permission in permissions:
+        GroupPagePermissionFactory(
+            page=listing_page, group=group, permission_type=permission)
+
+    user = UserFactory(
+        is_superuser=is_superuser, is_staff=is_staff, groups=[group]
+    )
+    user_password = password or 'test'
+    user.set_password(user_password)
+    user.save()
+
+    client = Client()
+    client.login(username=user.username, password=user_password)
+
+    return Branch(listing_page, article_page, group, user, client)
+
+
+def create_listing_with_article_and_group_with_editor_and_moderator(
+        root_page,
+        *,
+        editor_permissions=['add', 'edit'],
+        editor_password=None,
+        editor_is_superuser=False,
+        editor_is_staff=False,
+        moderator_permissions=['add', 'edit', 'publish'],
+        moderator_password=None,
+        moderator_is_superuser=False,
+        moderator_is_staff=False
+):
+    """Returns a listing page with a child page, user group, users & clients.
+
+    For Wagtail permission model check:
+    http://docs.wagtail.io/en/v2.0/topics/permissions.html#page-permissions
+    """
+    # ensure that only permissions supported by Wagtail are used
+    available_permissions = [p for p, _, _ in PAGE_PERMISSION_TYPES]
+    assert not (set(editor_permissions) - set(available_permissions))
+    assert not (set(moderator_permissions) - set(available_permissions))
+
+    listing_page = ArticleListingPageFactory(parent=root_page)
+    article_page = ArticlePageFactory(parent=listing_page)
+
+    editors = GroupFactory()
+    editors.permissions.add(Permission.objects.get(codename='access_admin'))
+    moderators = GroupFactory()
+    moderators.permissions.add(Permission.objects.get(codename='access_admin'))
+
+    for permission in editor_permissions:
+        GroupPagePermissionFactory(
+            page=listing_page, group=editors, permission_type=permission)
+    for permission in moderator_permissions:
+        GroupPagePermissionFactory(
+            page=listing_page, group=moderators, permission_type=permission)
+
+    editor = UserFactory(
+        is_superuser=editor_is_superuser,
+        is_staff=editor_is_staff,
+        groups=[editors],
+    )
+    editor_password = editor_password or 'test'
+    editor.set_password(editor_password)
+    editor.save()
+
+    moderator = UserFactory(
+        is_superuser=moderator_is_superuser,
+        is_staff=moderator_is_staff,
+        groups=[moderators],
+    )
+    moderator_password = moderator_password or 'test'
+    moderator.set_password(moderator_password)
+    moderator.save()
+
+    editor_client = Client()
+    editor_client.login(username=editor.username, password=editor_password)
+    moderator_client = Client()
+    moderator_client.login(
+        username=moderator.username,
+        password=moderator_password
+    )
+
+    return BranchEditorAndModerator(
+        listing_page,
+        article_page,
+        editors,
+        editor,
+        editor_client,
+        moderators,
+        moderator,
+        moderator_client
+    )
+
+
+class BranchEditorFactory:
+    @staticmethod
+    def get(root_page, *, permissions=['add', 'edit'], **kwargs):
+        return create_listing_with_article_and_group_with_user_and_client(
+            root_page,
+            permissions=permissions,
+            **kwargs,
+        )
+
+
+class BranchModeratorFactory:
+    @staticmethod
+    def get(root_page, *, permissions=['add', 'edit', 'publish'], **kwargs):
+        return create_listing_with_article_and_group_with_user_and_client(
+            root_page,
+            permissions=permissions,
+            **kwargs,
+        )
+
+
+class BranchEditorAndModeratorFactory:
+    @staticmethod
+    def get(root_page, **kwargs):
+        return create_listing_with_article_and_group_with_editor_and_moderator(
+            root_page,
+            **kwargs
+        )

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 
 import export_readiness.tests.factories as exred_factories
-from conftest import BranchEditorFactory, BranchModeratorFactory
+from users.tests.factories import BranchEditorFactory, BranchModeratorFactory
 
 
 @pytest.mark.quirk

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -424,7 +424,8 @@ def test_moderators_can_view_revisions_from_other_branches(
     revert_path_2 = f'/admin/pages/{branch_2.article.pk}/revisions/{revision_2.pk}/revert/'  # NOQA
 
     resp_1 = branch_1.editor_client.get(
-        reverse('wagtailadmin_pages:revisions_index', args=[branch_1.article.pk])
+        reverse('wagtailadmin_pages:revisions_index',
+                args=[branch_1.article.pk])
     )
     assert resp_1.status_code == status.HTTP_200_OK
     content_1 = resp_1.content.decode()
@@ -432,7 +433,8 @@ def test_moderators_can_view_revisions_from_other_branches(
     assert revert_path_2 not in content_1
 
     resp_2 = branch_1.editor_client.get(
-        reverse('wagtailadmin_pages:revisions_index', args=[branch_2.article.pk])
+        reverse('wagtailadmin_pages:revisions_index',
+                args=[branch_2.article.pk])
     )
     assert resp_2.status_code == status.HTTP_200_OK
     content_2 = resp_2.content.decode()
@@ -440,7 +442,8 @@ def test_moderators_can_view_revisions_from_other_branches(
     assert revert_path_2 in content_2
 
     resp_3 = branch_2.editor_client.get(
-        reverse('wagtailadmin_pages:revisions_index', args=[branch_1.article.pk])
+        reverse('wagtailadmin_pages:revisions_index',
+                args=[branch_1.article.pk])
     )
     assert resp_3.status_code == status.HTTP_200_OK
     content_3 = resp_3.content.decode()
@@ -448,7 +451,8 @@ def test_moderators_can_view_revisions_from_other_branches(
     assert revert_path_2 not in content_3
 
     resp_4 = branch_2.editor_client.get(
-        reverse('wagtailadmin_pages:revisions_index', args=[branch_2.article.pk])
+        reverse('wagtailadmin_pages:revisions_index',
+                args=[branch_2.article.pk])
     )
     assert resp_4.status_code == status.HTTP_200_OK
     content_4 = resp_4.content.decode()


### PR DESCRIPTION
New scenarios:
* test_branch_editors_should_only_see_pages_from_their_branch
* test_branch_moderators_should_only_see_pages_from_their_branch

*NOTE*
In admin Wagtail doesn't show to users. pages which don't belong to their *GroupPagePermission* but on the API Level it allows users to view pages from other branches!

I've also added 3 extra scenarios for CMS-840
- test_moderators_can_view_revisions_from_other_branches
- test_moderators_can_reject_revision
- test_moderators_cannot_reject_revision_from_other_branch