### PR TITLE
CMS-841 admins should be able to manage pages

### DIFF
--- a/find_a_supplier/tests/factories.py
+++ b/find_a_supplier/tests/factories.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import factory
 import factory.fuzzy
 import wagtail_factories
@@ -115,4 +117,23 @@ class IndustryContactPageFactory(wagtail_factories.PageFactory):
     success_message_text_en_gb = factory.fuzzy.FuzzyText(length=255)
     success_back_link_text_en_gb = factory.fuzzy.FuzzyText(length=100)
     slug = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    parent = None
+
+
+class IndustryArticlePageFactory(wagtail_factories.PageFactory):
+
+    class Meta:
+        model = models.IndustryArticlePage
+
+    breadcrumbs_label_en_gb = factory.fuzzy.FuzzyText(length=50)
+    introduction_title_en_gb = factory.fuzzy.FuzzyText(length=255)
+    body_en_gb = factory.fuzzy.FuzzyText(length=100)
+    author_name_en_gb = factory.fuzzy.FuzzyText(length=100)
+    job_title_en_gb = factory.fuzzy.FuzzyText(length=100)
+    proposition_text_en_gb = factory.fuzzy.FuzzyText(length=100)
+    call_to_action_text_en_gb = factory.fuzzy.FuzzyText(length=100)
+    back_to_home_link_text_en_gb = factory.fuzzy.FuzzyText(length=100)
+    social_share_title_en_gb = factory.fuzzy.FuzzyText(length=100)
+    date_en_gb = factory.LazyFunction(datetime.now)
+    slug = factory.Sequence(lambda n: 'IndustryArticlePage-{0}'.format(n))
     parent = None

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -221,3 +221,15 @@ class BranchModeratorFactory:
     @staticmethod
     def get(root_page, *, permissions=['add', 'edit', 'publish'], **kwargs):
         return branch_with_user(root_page, permissions=permissions, **kwargs)
+
+
+class AdminFactory:
+    @staticmethod
+    def get(root_page, *, permissions=['add', 'edit', 'publish'], **kwargs):
+        return branch_with_user(
+            root_page,
+            permissions=permissions,
+            is_superuser=True,
+            is_staff=True,
+            **kwargs
+        )

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -225,7 +225,12 @@ class BranchModeratorFactory:
 
 class AdminFactory:
     @staticmethod
-    def get(root_page, *, permissions=['add', 'edit', 'publish'], **kwargs):
+    def get(
+            root_page,
+            *,
+            permissions=['add', 'edit', 'publish', 'bulk_delete', 'lock'],
+            **kwargs
+    ):
         return branch_with_user(
             root_page,
             permissions=permissions,

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -127,6 +127,9 @@ def two_branches_with_users(root_page):
     """
 
     def set_permissions(page, user_group, permissions):
+        # ensure that only permissions supported by Wagtail are used
+        available_permissions = [p for p, _, _ in PAGE_PERMISSION_TYPES]
+        assert not (set(permissions) - set(available_permissions))
         for perm in permissions:
             GroupPagePermissionFactory(
                 page=page, group=user_group, permission_type=perm)

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -6,11 +6,8 @@ from django.contrib.auth.models import Group, Permission
 from django.test import Client
 from wagtail.core.models import GroupPagePermission, PAGE_PERMISSION_TYPES
 
-from export_readiness.tests.factories import (
-    ArticleListingPageFactory,
-    ArticlePageFactory,
-    TopicLandingPageFactory,
-)
+from export_readiness.tests import factories as exred
+from find_a_supplier.tests import factories as fas
 
 User = get_user_model()
 Branch = namedtuple(
@@ -21,7 +18,9 @@ TwoBranchesWithEditorModeratorAdmin = namedtuple(
         'admins',
         'admin',
         'admin_client',
+        'home_1',
         'landing_1',
+        'listing_1',
         'article_1',
         'editors_1',
         'editor_1',
@@ -29,7 +28,9 @@ TwoBranchesWithEditorModeratorAdmin = namedtuple(
         'moderators_1',
         'moderator_1',
         'moderator_1_client',
+        'home_2',
         'landing_2',
+        'listing_2',
         'article_2',
         'editors_2',
         'editor_2',
@@ -53,7 +54,7 @@ class GroupPagePermissionFactory(factory.django.DjangoModelFactory):
         model = GroupPagePermission
 
     group = factory.SubFactory(GroupFactory)
-    page = factory.SubFactory(ArticleListingPageFactory)
+    page = factory.SubFactory(exred.ArticleListingPageFactory)
     permission_type = 'add'
 
 
@@ -79,6 +80,15 @@ class UserFactory(factory.django.DjangoModelFactory):
                 self.groups.add(group)
 
 
+def set_permissions(page, user_group, permissions):
+    # ensure that only permissions supported by Wagtail are used
+    available_permissions = [p for p, _, _ in PAGE_PERMISSION_TYPES]
+    assert not (set(permissions) - set(available_permissions))
+    for perm in permissions:
+        GroupPagePermissionFactory(
+            page=page, group=user_group, permission_type=perm)
+
+
 def branch_with_user(
         root_page,
         *,
@@ -96,15 +106,12 @@ def branch_with_user(
     available_permissions = [p for p, _, _ in PAGE_PERMISSION_TYPES]
     assert not (set(permissions) - set(available_permissions))
 
-    listing_page = ArticleListingPageFactory(parent=root_page)
-    article_page = ArticlePageFactory(parent=listing_page)
+    listing_page = exred.ArticleListingPageFactory(parent=root_page)
+    article_page = exred.ArticlePageFactory(parent=listing_page)
 
     group = GroupFactory()
     group.permissions.add(Permission.objects.get(codename='access_admin'))
-
-    for permission in permissions:
-        GroupPagePermissionFactory(
-            page=listing_page, group=group, permission_type=permission)
+    set_permissions(listing_page, group, permissions)
 
     user = UserFactory(
         is_superuser=is_superuser, is_staff=is_staff, groups=[group]
@@ -121,25 +128,78 @@ def branch_with_user(
 
 def two_branches_with_users(root_page):
     """
-    Create 2 independent landing pages (also called branches),
-    with an article page, editor and moderator in each branch.
-    It also creates an Admin user associated with root_page.
+    Creates 2 independent branches (application):
+        1) ExRed
+        2) FAS
+
+    Each branch has a:
+        * home page
+        * landing page
+        * listing page
+        * article page
+        * editor (with [add, edit] permissions set to home page)
+        * moderator (with [add, edit, publish] permissions set to home page)
+
+    It also creates an Admin user associated with the root_page (pk=1).
+
+    Graph below depicts 'subpage_types' model dependency for all
+    current CMS clients:
+
+    root_page (pk=1)
+    |
+    |-> ExRed
+    |   |-> HomePage
+    |              |-> TopicLandingPage
+    |              |   |-> ArticleListingPage
+    |              |   |   |-> ArticlePage
+    |              |   |-> SuperregionPage
+    |              |       |-> CountryGuidePage
+    |              |           |-> ArticlePage
+    |              |-> ArticleListingPage
+    |              |   |-> ArticlePage
+    |              |-> ArticlePage
+    |-> FAS
+    |   |-> LandingPage  (subpage_types aren't defined)
+    |       |-> IndustryLandingPage
+    |           |-> IndustryContactPage
+    |           |-> IndustryPage
+    |               |-> IndustryArticlePage
+    |-> Invest
+    |   |-> InvestHomePage  (subpage_types aren't defined)
+    |       |-> RegionLandingPage
+    |       |   |-> sectorPage
+    |       |       |-> sectorPage
+    |       |-> SectorLandingPage
+    |       |   |-> SectorPage
+    |       |       |-> sectorPage
+    |       |-> SetupGuideLandingPage
+    |           |-> SetupGuidePage
+    |-> International
+        |-> InternationalHomePage
+            |-> InternationalTopicLandingPage
+            |   |-> InternationalArticleListingPage
+            |       |-> InternationalArticlePage
+            |-> InternationalArticleListingPage
+            |   |-> InternationalArticlePage
+            |-> InternationalArticlePage
+            |-> InternationalMarketingPages
+                |-> InternationalArticlePage
+                |-> InternationalCampaignPage
     """
 
-    def set_permissions(page, user_group, permissions):
-        # ensure that only permissions supported by Wagtail are used
-        available_permissions = [p for p, _, _ in PAGE_PERMISSION_TYPES]
-        assert not (set(permissions) - set(available_permissions))
-        for perm in permissions:
-            GroupPagePermissionFactory(
-                page=page, group=user_group, permission_type=perm)
+    home_page_1 = exred.HomePageFactory.create(parent=root_page)
+    home_page_2 = fas.LandingPageFactory.create(parent=root_page)
 
-    landing_page_1, landing_page_2 = TopicLandingPageFactory.create_batch(
-        2, parent=root_page, live=True
+    landing_page_1 = exred.TopicLandingPageFactory.create(parent=home_page_1)
+    landing_page_2 = fas.IndustryLandingPageFactory.create(parent=home_page_2)
+
+    listing_page_1 = exred.ArticleListingPageFactory.create(
+        parent=landing_page_1
     )
+    listing_page_2 = fas.IndustryPageFactory.create(parent=landing_page_2)
 
-    article_1 = ArticlePageFactory(parent=landing_page_1)
-    article_2 = ArticlePageFactory(parent=landing_page_2)
+    article_1 = exred.ArticlePageFactory(parent=listing_page_1)
+    article_2 = fas.IndustryArticlePageFactory(parent=listing_page_2)
 
     editors_1, moderators_1, editors_2, moderators_2, admins = \
         GroupFactory.create_batch(5)
@@ -151,10 +211,10 @@ def two_branches_with_users(root_page):
         admins,
         ['add', 'edit', 'publish', 'bulk_delete', 'lock']
     )
-    set_permissions(landing_page_1, editors_1, ['add', 'edit'])
-    set_permissions(landing_page_1, moderators_1, ['add', 'edit', 'publish'])
-    set_permissions(landing_page_2, editors_2, ['add', 'edit'])
-    set_permissions(landing_page_2, moderators_2, ['add', 'edit', 'publish'])
+    set_permissions(home_page_1, editors_1, ['add', 'edit'])
+    set_permissions(home_page_1, moderators_1, ['add', 'edit', 'publish'])
+    set_permissions(home_page_2, editors_2, ['add', 'edit'])
+    set_permissions(home_page_2, moderators_2, ['add', 'edit', 'publish'])
 
     password = 'test'
 
@@ -205,10 +265,10 @@ def two_branches_with_users(root_page):
 
     return TwoBranchesWithEditorModeratorAdmin(
         admins, admin, admin_client,
-        landing_page_1, article_1,
+        home_page_1, landing_page_1, listing_page_1, article_1,
         editors_1, editor_1, editor_1_client,
         moderators_1, moderator_1, moderator_1_client,
-        landing_page_2, article_2,
+        home_page_2, landing_page_2, listing_page_2, article_2,
         editors_2, editor_2, editor_2_client,
         moderators_2, moderator_2, moderator_2_client,
     )

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -2,7 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-import export_readiness.tests.factories as exred_factories
 from export_readiness.tests.factories import ArticlePageFactory
 from users.tests.factories import (
     AdminFactory,
@@ -26,14 +25,14 @@ def test_branch_editors_should_only_see_pages_from_their_branch(root_page):
     )
     assert resp_1.status_code == status.HTTP_200_OK
     assert resp_1.json()['meta']['total_count'] == 1
-    assert resp_1.json()['items'][0]['id'] == env.article_1.pk
+    assert resp_1.json()['items'][0]['id'] == env.listing_1.pk
 
     resp_2 = env.editor_2_client.get(
         f'/admin/api/v2beta/pages/?child_of={env.landing_2.pk}&for_explorer=1'
     )
     assert resp_2.status_code == status.HTTP_200_OK
     assert resp_2.json()['meta']['total_count'] == 1
-    assert resp_2.json()['items'][0]['id'] == env.article_2.pk
+    assert resp_2.json()['items'][0]['id'] == env.listing_2.pk
 
 
 @pytest.mark.quirk
@@ -46,19 +45,19 @@ def test_branch_editors_cannot_access_pages_not_from_their_branch(root_page):
     """
     env = two_branches_with_users(root_page)
 
-    resp_1 = env.editor_1_client.get(f'/admin/pages/{env.landing_2.pk}/edit/')
+    resp_1 = env.editor_1_client.get(f'/admin/pages/{env.home_2.pk}/edit/')
     assert resp_1.status_code == status.HTTP_403_FORBIDDEN
 
-    resp_2 = env.editor_2_client.get(f'/admin/pages/{env.landing_1.pk}/edit/')
+    resp_2 = env.editor_2_client.get(f'/admin/pages/{env.home_1.pk}/edit/')
     assert resp_2.status_code == status.HTTP_403_FORBIDDEN
 
-    resp_3 = env.editor_1_client.get(f'/admin/pages/{env.landing_2.pk}/')
+    resp_3 = env.editor_1_client.get(f'/admin/pages/{env.home_2.pk}/')
     assert resp_3.status_code == status.HTTP_302_FOUND
-    assert resp_3.url == f'/admin/pages/{env.landing_1.pk}/'
+    assert resp_3.url == f'/admin/pages/{env.home_1.pk}/'
 
-    resp_4 = env.editor_2_client.get(f'/admin/pages/{env.landing_1.pk}/')
+    resp_4 = env.editor_2_client.get(f'/admin/pages/{env.home_1.pk}/')
     assert resp_4.status_code == status.HTTP_302_FOUND
-    assert resp_4.url == f'/admin/pages/{env.landing_2.pk}/'
+    assert resp_4.url == f'/admin/pages/{env.home_2.pk}/'
 
     # Unfortunately on API level Wagtail allows users to list pages that
     # belong to different branch
@@ -67,7 +66,7 @@ def test_branch_editors_cannot_access_pages_not_from_their_branch(root_page):
     )
     assert resp_6.status_code == status.HTTP_200_OK
     assert resp_6.json()['meta']['total_count'] == 1
-    assert resp_6.json()['items'][0]['id'] == env.article_2.pk
+    assert resp_6.json()['items'][0]['id'] == env.listing_2.pk
 
 
 @pytest.mark.CMS_837
@@ -84,14 +83,14 @@ def test_branch_moderators_should_only_see_pages_from_their_branch(root_page):
     )
     assert resp_1.status_code == status.HTTP_200_OK
     assert resp_1.json()['meta']['total_count'] == 1
-    assert resp_1.json()['items'][0]['id'] == env.article_1.pk
+    assert resp_1.json()['items'][0]['id'] == env.listing_1.pk
 
     resp_2 = env.moderator_2_client.get(
         f'/admin/api/v2beta/pages/?child_of={env.landing_2.pk}&for_explorer=1'
     )
     assert resp_2.status_code == status.HTTP_200_OK
     assert resp_2.json()['meta']['total_count'] == 1
-    assert resp_2.json()['items'][0]['id'] == env.article_2.pk
+    assert resp_2.json()['items'][0]['id'] == env.listing_2.pk
 
 
 @pytest.mark.quirk
@@ -105,22 +104,22 @@ def test_moderators_cannot_access_pages_not_from_their_branch(root_page):
     env = two_branches_with_users(root_page)
 
     resp_1 = env.moderator_1_client.get(
-        f'/admin/pages/{env.landing_2.pk}/edit/'
+        f'/admin/pages/{env.home_2.pk}/edit/'
     )
     assert resp_1.status_code == status.HTTP_403_FORBIDDEN
 
     resp_2 = env.moderator_2_client.get(
-        f'/admin/pages/{env.landing_1.pk}/edit/'
+        f'/admin/pages/{env.home_1.pk}/edit/'
     )
     assert resp_2.status_code == status.HTTP_403_FORBIDDEN
 
-    resp_3 = env.moderator_1_client.get(f'/admin/pages/{env.landing_2.pk}/')
+    resp_3 = env.moderator_1_client.get(f'/admin/pages/{env.home_2.pk}/')
     assert resp_3.status_code == status.HTTP_302_FOUND
-    assert resp_3.url == f'/admin/pages/{env.landing_1.pk}/'
+    assert resp_3.url == f'/admin/pages/{env.home_1.pk}/'
 
-    resp_4 = env.moderator_2_client.get(f'/admin/pages/{env.landing_1.pk}/')
+    resp_4 = env.moderator_2_client.get(f'/admin/pages/{env.home_1.pk}/')
     assert resp_4.status_code == status.HTTP_302_FOUND
-    assert resp_4.url == f'/admin/pages/{env.landing_2.pk}/'
+    assert resp_4.url == f'/admin/pages/{env.home_2.pk}/'
 
     # Unfortunately on API level Wagtail allows users to list pages that
     # belong to different branch
@@ -129,7 +128,7 @@ def test_moderators_cannot_access_pages_not_from_their_branch(root_page):
     )
     assert resp_6.status_code == status.HTTP_200_OK
     assert resp_6.json()['meta']['total_count'] == 1
-    assert resp_6.json()['items'][0]['id'] == env.article_2.pk
+    assert resp_6.json()['items'][0]['id'] == env.listing_2.pk
 
 
 @pytest.mark.django_db
@@ -138,10 +137,9 @@ def test_moderators_can_approve_revisions_only_for_pages_in_their_branch(
 ):
     env = two_branches_with_users(root_page)
 
-    draft_page = exred_factories.ArticlePageFactory(
-        parent=env.landing_2, live=False
-    )
-    revision = draft_page.save_revision(
+    new_title = 'The title was modified'
+    env.article_2.title = new_title
+    revision = env.article_2.save_revision(
         user=env.editor_2, submitted_for_moderation=True
     )
 
@@ -259,6 +257,7 @@ def test_branch_user_cant_create_pages_in_branch_they_dont_manage(
         'article_body_text': 'test article',
         'title_en_gb': 'test article',
         'slug': 'test-article',
+        'action-publish': 'action-publish',
     }
 
     resp = branch_1.client.post(
@@ -279,28 +278,63 @@ def test_branch_user_cant_create_pages_in_branch_they_dont_manage(
 @pytest.mark.django_db
 def test_admins_can_create_pages_in_any_branch(root_page):
     env = two_branches_with_users(root_page)
-    data = {
+
+    # Add ExRed Article page
+    data_1 = {
         'article_title': 'test article',
         'article_teaser': 'test article',
         'article_body_text': 'test article',
         'title_en_gb': 'test article',
         'slug': 'test-article',
+        'action-publish': 'action-publish',
     }
 
-    resp = env.admin_client.post(
+    resp_1 = env.admin_client.post(
+        reverse(
+            'wagtailadmin_pages:add',
+            args=[
+                env.article_1._meta.app_label,
+                env.article_1._meta.model_name,
+                env.listing_1.pk
+            ],
+        ),
+        data=data_1,
+    )
+    assert resp_1.status_code == status.HTTP_302_FOUND
+    assert resp_1.url.startswith('/admin/pages/')  # format is /admin/pages/3/
+    
+    # Add FAS Industry Article page
+    data_2 = {
+        'article_title': 'test article',
+        'article_teaser': 'test article',
+        'article_body_text': 'test article',
+        'title_en_gb': 'test article',
+        'body': 'this is a test page',
+        'slug': 'test-article',
+        'action-publish': 'action-publish',
+        'breadcrumbs_label_en_gb': 'test breadcrumb',
+        'introduction_title_en_gb': 'test introduction',
+        'author_name_en_gb': 'dit',
+        'job_title_en_gb': 'dit',
+        'proposition_text_en_gb': 'test proposition',
+        'call_to_action_text_en_gb': 'contact us',
+        'back_to_home_link_text_en_gb': 'home',
+        'social_share_title_en_gb': 'share',
+        'date_en_gb': '2019-01-01',
+    }
+    resp_2 = env.admin_client.post(
         reverse(
             'wagtailadmin_pages:add',
             args=[
                 env.article_2._meta.app_label,
                 env.article_2._meta.model_name,
-                env.landing_2.pk
+                env.listing_2.pk
             ],
         ),
-        data=data,
+        data=data_2,
     )
-    assert resp.status_code == status.HTTP_302_FOUND
-    assert resp.url.startswith('/admin/pages/')  # format is /admin/pages/3/edit/  # NOQA
-    assert resp.url.endswith('/edit/')  # format is /admin/pages/3/edit/
+    assert resp_2.status_code == status.HTTP_302_FOUND
+    assert resp_2.url.startswith('/admin/pages/')  # format is /admin/pages/3/
 
 
 @pytest.mark.CMS_839

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -728,11 +728,11 @@ def test_admins_should_be_able_to_reject_revision_from_any_branch(root_page):
 
 @pytest.mark.CMS_841
 @pytest.mark.django_db
-def test_admins_should_have_permissions_to_add_users(
+def test_admins_should_have_permissions_to_manage_users(
         admin_factory, root_page
 ):
+    """Admins should have all required permissions to manage users."""
     admin = admin_factory.get(root_page)
-
     permissions = {
         'auth.add_group',
         'auth.add_permission',
@@ -747,5 +747,4 @@ def test_admins_should_have_permissions_to_add_users(
         'wagtailusers.change_userprofile',
         'wagtailusers.delete_userprofile',
     }
-    # Admins should have all required permissions to manage users
     assert not (permissions - admin.user.get_all_permissions())

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -277,12 +277,8 @@ def test_branch_user_cant_create_pages_in_branch_they_dont_manage(
 
 @pytest.mark.CMS_841
 @pytest.mark.django_db
-def test_admins_can_create_pages_in_any_branch(
-        admin_factory, distinct_root_pages
-):
-    root_page_1, root_page_2 = distinct_root_pages
-    branch_1 = admin_factory.get(root_page_1)
-    branch_2 = admin_factory.get(root_page_2)
+def test_admins_can_create_pages_in_any_branch(root_page):
+    env = two_branches_with_users(root_page)
     data = {
         'article_title': 'test article',
         'article_teaser': 'test article',
@@ -291,13 +287,13 @@ def test_admins_can_create_pages_in_any_branch(
         'slug': 'test-article',
     }
 
-    resp = branch_1.client.post(
+    resp = env.admin_client.post(
         reverse(
             'wagtailadmin_pages:add',
             args=[
-                branch_2.article._meta.app_label,
-                branch_2.article._meta.model_name,
-                branch_2.listing.pk
+                env.article_2._meta.app_label,
+                env.article_2._meta.model_name,
+                env.landing_2.pk
             ],
         ),
         data=data,

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -275,6 +275,38 @@ def test_branch_user_cant_create_pages_in_branch_they_dont_manage(
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
+@pytest.mark.CMS_841
+@pytest.mark.django_db
+def test_branch_user_can_create_pages_in_any_branch(
+        admin_factory, distinct_root_pages
+):
+    root_page_1, root_page_2 = distinct_root_pages
+    branch_1 = admin_factory.get(root_page_1)
+    branch_2 = admin_factory.get(root_page_2)
+    data = {
+        'article_title': 'test article',
+        'article_teaser': 'test article',
+        'article_body_text': 'test article',
+        'title_en_gb': 'test article',
+        'slug': 'test-article',
+    }
+
+    resp = branch_1.client.post(
+        reverse(
+            'wagtailadmin_pages:add',
+            args=[
+                branch_2.article._meta.app_label,
+                branch_2.article._meta.model_name,
+                branch_2.listing.pk
+            ],
+        ),
+        data=data,
+    )
+    assert resp.status_code == status.HTTP_302_FOUND
+    assert resp.url.startswith('/admin/pages/')  # format is /admin/pages/3/edit/  # NOQA
+    assert resp.url.endswith('/edit/')  # format is /admin/pages/3/edit/
+
+
 @pytest.mark.CMS_839
 @pytest.mark.django_db
 def test_editors_cannot_publish_child_pages(root_page):

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -724,11 +724,9 @@ def test_admins_should_be_able_to_reject_revision_from_any_branch(root_page):
 
 @pytest.mark.CMS_841
 @pytest.mark.django_db
-def test_admins_should_have_permissions_to_manage_users(
-        admin_factory, root_page
-):
+def test_admins_should_have_permissions_to_manage_users(root_page):
     """Admins should have all required permissions to manage users."""
-    admin = admin_factory.get(root_page)
+    admin = AdminFactory.get(root_page)
     permissions = {
         'auth.add_group',
         'auth.add_permission',

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -5,6 +5,7 @@ from rest_framework import status
 import export_readiness.tests.factories as exred_factories
 from export_readiness.tests.factories import ArticlePageFactory
 from users.tests.factories import (
+    AdminFactory,
     BranchEditorFactory,
     BranchModeratorFactory,
     two_branches_with_users,

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -277,7 +277,7 @@ def test_branch_user_cant_create_pages_in_branch_they_dont_manage(
 
 @pytest.mark.CMS_841
 @pytest.mark.django_db
-def test_branch_user_can_create_pages_in_any_branch(
+def test_admins_can_create_pages_in_any_branch(
         admin_factory, distinct_root_pages
 ):
     root_page_1, root_page_2 = distinct_root_pages
@@ -724,3 +724,28 @@ def test_admins_should_be_able_to_reject_revision_from_any_branch(root_page):
     )
     assert resp_4.status_code == status.HTTP_200_OK
     assert 'rejected for publication' in resp_4.content.decode()
+
+
+@pytest.mark.CMS_841
+@pytest.mark.django_db
+def test_admins_should_have_permissions_to_add_users(
+        admin_factory, root_page
+):
+    admin = admin_factory.get(root_page)
+
+    permissions = {
+        'auth.add_group',
+        'auth.add_permission',
+        'auth.add_user',
+        'auth.change_group',
+        'auth.change_permission',
+        'auth.change_user',
+        'auth.delete_group',
+        'auth.delete_permission',
+        'auth.delete_user',
+        'wagtailusers.add_userprofile',
+        'wagtailusers.change_userprofile',
+        'wagtailusers.delete_userprofile',
+    }
+    # Admins should have all required permissions to manage users
+    assert not (permissions - admin.user.get_all_permissions())

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -302,7 +302,7 @@ def test_admins_can_create_pages_in_any_branch(root_page):
     )
     assert resp_1.status_code == status.HTTP_302_FOUND
     assert resp_1.url.startswith('/admin/pages/')  # format is /admin/pages/3/
-    
+
     # Add FAS Industry Article page
     data_2 = {
         'article_title': 'test article',

--- a/users/tests/test_permissions.py
+++ b/users/tests/test_permissions.py
@@ -437,7 +437,7 @@ def test_branch_user_can_list_revisions(branch_factory, root_page):
         BranchModeratorFactory,
         AdminFactory,
     ])
-def test_editors_can_compare_changes_between_revisions(
+def test_branch_user_can_compare_changes_between_revisions(
         branch_factory, root_page
 ):
     branch = branch_factory.get(root_page)


### PR DESCRIPTION
This [ticket](https://uktrade.atlassian.net/browse/CMS-841)

This PR introduces 3 new tests:
- test_admins_can_create_pages_in_any_branch
- test_admins_can_reject_revision
- test_admins_should_have_permissions_to_manage_users

and fixes issues caused by wrong branch (application) subpage dependencies.