### PR TITLE
Integrate link chooser with SimpleMDE, using slug links (TOR-83, CMS-991)

### DIFF
--- a/core/static/core/js/refresh_codemirror.js
+++ b/core/static/core/js/refresh_codemirror.js
@@ -38,17 +38,16 @@ function _replaceSelection(cm, active, startEnd, url) {
     }, 1);
 }
 
-const windowPrompt = window.prompt;
+var windowPrompt = window.prompt;
+window.prompt = windowPromptOverride;
 
-const OVERRIDE_TEXT = 'windowPromptOverride';
+function windowPromptOverride(value) {
+    var isOverride = value instanceof SimpleMDE;
 
-const windowPromptOverride = (callback, text) => {
-    const shouldOverride = text === OVERRIDE_TEXT;
-
-    if (shouldOverride) {
-        callback();
+    if (isOverride) {
+        openLinkChooser(value);
     } else {
-        return windowPrompt(text);
+        return windowPrompt(value);
     }
 }
 
@@ -90,16 +89,16 @@ function simplemdeAttach(id) {
         autofocus: false,
     });
     mde.options.promptTexts = {
-        link: OVERRIDE_TEXT,
+        // We pass the editor instance as the prompt text for links in order to:
+        // - Override window.prompt in the appropriate scenarios.
+        // - Have access to the editor instance in our custom link chooser.
+        link: mde,
     };
     mde.render();
 
     mde.codemirror.on('change', function() {
         $('#' + id).val(mde.value());
     });
-
-    // TODO Make sure this is compatible with multiple instances of SimpleMDE on the page.
-    window.prompt = windowPromptOverride.bind(null, openLinkChooser.bind(null, mde));
 }
 
 // Refresh the markdown entry field when the tab buttons are clicked.

--- a/core/static/core/js/refresh_codemirror.js
+++ b/core/static/core/js/refresh_codemirror.js
@@ -1,5 +1,7 @@
-// Extracted from simplemde source:
-// https://github.com/sparksuite/simplemde-markdown-editor/blob/6abda7ab68cc20f4aca870eb243747951b90ab04/src/js/simplemde.js#L791-L822
+/**
+ * Extracted from simplemde source:
+ * https://github.com/sparksuite/simplemde-markdown-editor/blob/6abda7ab68cc20f4aca870eb243747951b90ab04/src/js/simplemde.js#L791-L822
+ */
 function _replaceSelection(cm, active, startEnd, url) {
     if (
         /editor-preview-active/.test(cm.getWrapperElement().lastChild.className)
@@ -34,27 +36,34 @@ function _replaceSelection(cm, active, startEnd, url) {
     cm.setSelection(startPoint, endPoint);
 }
 
+function onLinkChosen(mde, data) {
+    var cm = mde.codemirror;
+
+    if (data.prefer_this_title_as_link_text) {
+        // Override the whole selection with link text + URL from the chooser.
+        cm.replaceSelection('[' + data.title + '](' + data.url + ')');
+    } else {
+        var isPageLink = !!data.slug;
+        var url = isPageLink ? 'slug:' + data.slug : data.url;
+        _replaceSelection(cm, mde.getState().link, ['[', '](#url#)'], url);
+    }
+}
+
 function openLinkChooser(mde) {
+    var cm = mde.codemirror;
+
     var workflow = window.ModalWorkflow({
         url: window.chooserUrls.pageChooser,
         urlParams: {
             page_type: 'wagtailcore.page',
             allow_external_link: true,
             allow_email_link: true,
-            // TODO Could be nice to implement this.
-            link_text: '',
+            link_text: cm.getSelection(),
         },
         onload: window.PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
         responses: {
             pageChosen: function(data) {
-                var isPageLink = !!data.id;
-                var href = isPageLink ? 'slug:' + data.slug : data.url;
-                _replaceSelection(
-                    mde.codemirror,
-                    mde.getState().link,
-                    ['[', '](#url#)'],
-                    href,
-                );
+                onLinkChosen(mde, data);
                 workflow.close();
             },
         },

--- a/core/static/core/js/refresh_codemirror.js
+++ b/core/static/core/js/refresh_codemirror.js
@@ -1,22 +1,112 @@
-function simplemdeAttach(id) {
-        var mde = new SimpleMDE({
-            element: document.getElementById(id),
-            autofocus: false,
-        });
-        mde.render();
+// Extracted from simplemde source:
+// https://github.com/sparksuite/simplemde-markdown-editor/blob/6abda7ab68cc20f4aca870eb243747951b90ab04/src/js/simplemde.js#L791-L822
+function _replaceSelection(cm, active, startEnd, url) {
+    if (
+        /editor-preview-active/.test(cm.getWrapperElement().lastChild.className)
+    )
+        return;
 
-        mde.codemirror.on("change", function(){
-            $('#' + id).val(mde.value());
-        });
+    var text;
+    var start = startEnd[0];
+    var end = startEnd[1];
+    var startPoint = cm.getCursor('start');
+    var endPoint = cm.getCursor('end');
+    if (url) {
+        end = end.replace('#url#', url);
     }
+    if (active) {
+        text = cm.getLine(startPoint.line);
+        start = text.slice(0, startPoint.ch);
+        end = text.slice(startPoint.ch);
+        cm.replaceRange(start + end, {
+            line: startPoint.line,
+            ch: 0,
+        });
+    } else {
+        text = cm.getSelection();
+        cm.replaceSelection(start + text + end);
 
+        startPoint.ch += start.length;
+        if (startPoint !== endPoint) {
+            endPoint.ch += start.length;
+        }
+    }
+    cm.setSelection(startPoint, endPoint);
+    // Not entirely sure why this is necessary! Prevents a stacktrace from jQuery when putting focus back into the editor.
+    setTimeout(() => {
+        cm.focus();
+    }, 1);
+}
+
+const windowPrompt = window.prompt;
+
+const OVERRIDE_TEXT = 'windowPromptOverride';
+
+const windowPromptOverride = (callback, text) => {
+    const shouldOverride = text === OVERRIDE_TEXT;
+
+    if (shouldOverride) {
+        callback();
+    } else {
+        return windowPrompt(text);
+    }
+}
+
+function openLinkChooser(mde) {
+    const workflow = window.ModalWorkflow({
+        url: window.chooserUrls.pageChooser,
+        urlParams: {
+            page_type: 'wagtailcore.page',
+            allow_external_link: true,
+            allow_email_link: true,
+            // TODO Could be nice to implement this.
+            link_text: '',
+        },
+        onload: window.PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
+        responses: {
+            pageChosen: (data) => {
+                const isPage = !!data.id;
+                const href = isPage ? `slug:${data.slug}` : data.url;
+                _replaceSelection(
+                    mde.codemirror,
+                    mde.getState().link,
+                    ['[', '](#url#)'],
+                    href,
+                );
+                workflow.close();
+            },
+        },
+        // TODO Add basic error handling.
+        onError: () => {
+            window.alert('Error');
+        },
+    });
+}
+
+function simplemdeAttach(id) {
+    var mde = new SimpleMDE({
+        element: document.getElementById(id),
+        promptURLs: true,
+        autofocus: false,
+    });
+    mde.options.promptTexts = {
+        link: OVERRIDE_TEXT,
+    };
+    mde.render();
+
+    mde.codemirror.on('change', function() {
+        $('#' + id).val(mde.value());
+    });
+
+    // TODO Make sure this is compatible with multiple instances of SimpleMDE on the page.
+    window.prompt = windowPromptOverride.bind(null, openLinkChooser.bind(null, mde));
+}
 
 // Refresh the markdown entry field when the tab buttons are clicked.
 // This works around a problem where CodeMirror cannot determine it's height
 // if it is hidden. Tab contents are of course hidden before they are clicked.
 // Unless this is done the markdown entry field will appear empty until clicked.
 (function() {
-
     var checkExist = setInterval(function() {
         if (document.getElementsByClassName('tab-nav')) {
             clearInterval(checkExist);
@@ -33,5 +123,4 @@ function simplemdeAttach(id) {
             codeElement.CodeMirror.refresh();
         }
     }
-
 })();

--- a/core/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/core/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -1,0 +1,18 @@
+{% load l10n %}
+
+{% comment %}
+The title field for a page in the page listing, when in 'choose' mode.
+
+Expects a variable 'page', the page instance.
+{% endcomment %}
+
+<h2>
+    {% if page.can_choose %}
+        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-slug="{{ page.slug|unlocalize }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+    {% else %}
+        {{ page.get_admin_display_title }}
+    {% endif %}
+
+    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
+    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
+</h2>

--- a/core/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/core/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -1,9 +1,8 @@
 {% load l10n %}
 
 {% comment %}
-The title field for a page in the page listing, when in 'choose' mode.
-
-Expects a variable 'page', the page instance.
+Override Wagtail’s https://github.com/wagtail/wagtail/blob/3134ffa119c15097c8b3c2a0422dd89f7c23304a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html,
+only to add a single `data-slug` attribute so it can be used by the page chooser UI.
 {% endcomment %}
 
 <h2>

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -20,6 +20,7 @@ class MarkdownTextarea(WidgetWithScript, forms.widgets.Textarea):
             },
             js=(
                 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js',
-                'core/js/refresh_codemirror.js'
+                'core/js/refresh_codemirror.js',
+                'wagtailadmin/js/page-chooser-modal.js',
             )
         )


### PR DESCRIPTION
Addresses [TOR-83](https://uktrade.atlassian.net/browse/TOR-83), [CMS-991](https://uktrade.atlassian.net/browse/CMS-991) (same task).

This integrates Wagtail’s existing link chooser UI with the current Markdown editor, so end users can create internal links without having to manually enter the slug of pages. Links are created with the same syntax as before, so for Markdown processing this should work the same. And for users who want to manually enter links, this is also doable like before.

Quick GIF demo:

![tor-83-demo](https://user-images.githubusercontent.com/877585/54924574-9c2a6b80-4f04-11e9-8c77-65db4a56f635.gif)

I wasn't sure how to test this, considering all of the behavior is in client-side JS, so here's the manual test plan I followed:

- Features
  - [x] Internal page links on selected text should decorate the text
  - [x] Internal page links without a selection should have empty link brackets (`[]`)
  - [x] External/email links with link text override, and selected text, should override
  - [x] External/email links with link text override, without a selection, should insert the link text
- Cross-browser tests:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11
  - [x] Edge
- Other
  - [x] Supports multiple Markdown editors on the page (kind of obvious – but my previous PoC didn't! https://github.com/torchbox/dit_directory_cms_poc/pull/1)
  - [x] No regression in the operation of the image control in the toolbar (because of `window.prompt` override)
  - [x] Error message if the link chooser modal does not load 