### PR TITLE
CMS-1228: Add a delete button for pages where there is no specific type 

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -2,6 +2,7 @@ from itertools import product
 
 import pytest
 from modeltranslation.utils import build_localized_fieldname
+from wagtail.core.models import Page
 from wagtail.documents.models import Document
 
 from find_a_supplier.tests.factories import (
@@ -17,6 +18,13 @@ def page(root_page):
         parent=root_page,
         slug='the-slug'
     )
+
+
+@pytest.fixture
+def page_without_specific_type(root_page):
+    page = Page(title="No specific type", slug='no-specific-type')
+    root_page.add_child(page)
+    return page
 
 
 @pytest.fixture

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -23,7 +23,7 @@ def page(root_page):
 @pytest.fixture
 def page_without_specific_type(root_page):
     page = Page(title="No specific type", slug='no-specific-type')
-    root_page.add_child(page)
+    root_page.add_child(instance=page)
     return page
 
 

--- a/core/tests/test_wagtail_hooks.py
+++ b/core/tests/test_wagtail_hooks.py
@@ -20,16 +20,24 @@ def test_update_default_listing_buttons_from_base_page(page_with_reversion):
 
 @pytest.mark.django_db
 def test_update_default_listing_buttons_not_from_base_page(
-    settings, root_page
+    settings, root_page, page_without_specific_type
 ):
     translation.activate(settings.LANGUAGE_CODE)
 
+    # For the root page, only the 'Add child page' button should be present
     buttons = wagtail_hooks.update_default_listing_buttons(
         page=root_page, page_perms=Mock()
     )
-
     assert len(buttons) == 1
     assert buttons[0].label == 'Add child page'
+
+    # For any other page without a type, there should also be a 'Delete' button
+    buttons = wagtail_hooks.update_default_listing_buttons(
+        page=page_without_specific_type, page_perms=Mock()
+    )
+    assert len(buttons) == 2
+    assert buttons[0].label == 'Add child page'
+    assert buttons[1].label == 'Delete'
 
 
 @pytest.mark.django_db

--- a/core/tests/test_wagtail_hooks.py
+++ b/core/tests/test_wagtail_hooks.py
@@ -20,18 +20,12 @@ def test_update_default_listing_buttons_from_base_page(page_with_reversion):
 
 @pytest.mark.django_db
 def test_update_default_listing_buttons_not_from_base_page(
-    settings, root_page, page_without_specific_type
+    settings, page_without_specific_type
 ):
     translation.activate(settings.LANGUAGE_CODE)
 
-    # For the root page, only the 'Add child page' button should be present
-    buttons = wagtail_hooks.update_default_listing_buttons(
-        page=root_page, page_perms=Mock()
-    )
-    assert len(buttons) == 1
-    assert buttons[0].label == 'Add child page'
-
-    # For any other page without a type, there should also be a 'Delete' button
+    # For a page without a type, there should also be an 'Add child page'
+    # and 'Delete' button
     buttons = wagtail_hooks.update_default_listing_buttons(
         page=page_without_specific_type, page_perms=Mock()
     )

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -47,7 +47,9 @@ def update_default_listing_buttons(page, page_perms, is_parent=False):
             buttons.append(PageListingButton(
                 'Delete',
                 reverse('wagtailadmin_pages:delete', args=[page.id]),
-                attrs={'title': "Delete '%s'" % page.get_admin_display_title()},
+                attrs={
+                    'title': "Delete '%s'" % page.get_admin_display_title()
+                },
             ))
     return buttons
 

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from wagtail.admin.widgets import Button
+from wagtail.admin.widgets import Button, PageListingButton
 from wagtail.core import hooks
 from wagtail.admin.wagtail_hooks import page_listing_buttons
 
@@ -33,13 +33,22 @@ def update_default_listing_buttons(page, page_perms, is_parent=False):
         for button in buttons:
             if helpers.get_button_url_name(button) == 'view_draft':
                 button.url = page.get_url(is_draft=True)
+
     else:
-        # for non-subclasses-of-BasePage allow only adding children
+        # limit buttons for non-subclasses-of-BasePage
         allowed_urls = ['add_subpage']
         buttons = [
             button for button in buttons
             if helpers.get_button_url_name(button) in allowed_urls
         ]
+        # since the drop-down is removed by the above, add a delete
+        # button to this list
+        if page_perms.can_delete():
+            buttons.append(PageListingButton(
+                'Delete',
+                reverse('wagtailadmin_pages:delete', args=[page.id]),
+                attrs={'title': "Delete '%s'" % page.get_admin_display_title()},
+            ))
     return buttons
 
 


### PR DESCRIPTION
When a page has no specific type (likely due to the page's type being removed), show a delete button in the page listing, so that the page can be deleted from the UI.

Wagtail has [special case handling](https://github.com/wagtail/wagtail/blob/master/wagtail/core/models.py#L1727) in `PagePermissionTester.can_delete()` for the root page, that will prevent the delete button from appearing for that particular page.