### PR TITLE
[CMS-1396] Surface the 'uses_tree_based_routing' checkbox in the CMS for all international page types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [CI-101](https://uktrade.atlassian.net/browse/CI-101) Added Investor Support Directory section to `InvestHomePage` 
 - [CMS-1397](https://uktrade.atlassian.net/browse/CMS-1397) Updated custom url methods on `BasePage` to support tree-based routing when enabled
 - [CMS-13998](https://uktrade.atlassian.net/browse/CMS-13998) Replaced unused `lookup_by_full_path` API endpoint with new `lookup_by_path` API endpoint to support tree-based routing
+- [CMS-1396](https://uktrade.atlassian.net/browse/CMS-1396) Made 'uses_tree_based_routing' field editable in the CMS for all international page types
 
 ## [2019.04.24](https://github.com/uktrade/directory-cms/releases/tag/2019.04.24)
 [Full Changelog](https://github.com/uktrade/directory-cms/compare/2019.04.10...2019.04.24)

--- a/great_international/models.py
+++ b/great_international/models.py
@@ -455,6 +455,7 @@ class InternationalSectorPage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -878,6 +879,7 @@ class InternationalHomePage(
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
     ]
 
     edit_handler = make_translated_interface(
@@ -898,6 +900,7 @@ class InternationalRegionPage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -916,6 +919,7 @@ class InternationalLocalisedFolderPage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
     ]
 
     def save(self, *args, **kwargs):
@@ -1012,6 +1016,7 @@ class InternationalArticlePage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -1066,6 +1071,7 @@ class InternationalArticleListingPage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -1308,6 +1314,7 @@ class InternationalCampaignPage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -1353,6 +1360,7 @@ class InternationalTopicLandingPage(BasePage):
     settings_panels = [
         FieldPanel('title_en_gb'),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -1483,6 +1491,7 @@ class InternationalCuratedTopicLandingPage(BasePage):
         FieldPanel('title_en_gb'),
         SearchEngineOptimisationPanel(),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 
@@ -1591,6 +1600,7 @@ class InternationalGuideLandingPage(BasePage):
         FieldPanel('title_en_gb'),
         SearchEngineOptimisationPanel(),
         FieldPanel('slug'),
+        FieldPanel('uses_tree_based_routing'),
         FieldPanel('tags', widget=CheckboxSelectMultiple)
     ]
 


### PR DESCRIPTION
This will allow us to begin activating the new functionality for individual pages in the international app, but not elsewhere.