### PR TITLE
CMS-1449 Upgrade to wagtailmedia 0.3.0, for Wagtail 2.4+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [CMS-1417](https://uktrade.atlassian.net/browse/CMS-1417) Integrate staff SSO
 - [CMS-1462](https://uktrade.atlassian.net/browse/CMS-1462) Remove char limit from fields in `InternationalArticlePage`
+- [CMS-1449](https://uktrade.atlassian.net/browse/CMS-1449) Upgrade to wagtailmedia 0.3.0, for future Wagtail 2.4+ compat
 
 
 ## [2019.05.03](https://github.com/uktrade/directory-cms/releases/tag/2019.05.03)

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ directory-constants==14.7.0
 django-staff-sso-client==0.2.0
 html2text==2018.1.9
 wagtail==2.3
-wagtailmedia==0.2.0
+wagtailmedia==0.3.0
 pytube==9.2.2
 django-filter==1.0.4
 django-redis==4.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ urllib3==1.24.2
 vine==1.1.4               # via amqp
 w3lib==1.20.0
 wagtail==2.3
-wagtailmedia==0.2.0
+wagtailmedia==0.3.0
 webencodings==0.5.1       # via bleach, html5lib
 whitenoise==3.1
 willow==1.1               # via wagtail

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -92,7 +92,7 @@ vine==1.1.4               # via amqp
 w3lib==1.20.0
 wagtail-factories==1.0.0
 wagtail==2.3
-wagtailmedia==0.2.0
+wagtailmedia==0.3.0
 webencodings==0.5.1       # via bleach, html5lib
 whitenoise==3.1
 willow==1.1               # via wagtail


### PR DESCRIPTION
See [CMS-1449](https://uktrade.atlassian.net/browse/CMS-1449).

This should make it easier to upgrade to a more recent Wagtail version once we get there. The 0.3.0 release does not introduce any changes except for Wagtail 2.4 & 2.5 compatibility, but APIs used by directory-cms haven't changed. The released changes have been tested against this project with Django 1.11 and Wagtail 2.3, and also a regular Wagtail build with Django 2.2 and Wagtail 2.6-dev (latest changes from Wagtail master).

I've tested this manually by interacting with the Media section of the admin, and the media chooser modal. Everything seems to be working as expected. Also ran through a longer list of manual tests before making the release, https://github.com/torchbox/wagtailmedia/pull/43.