### PR TITLE
[CMS-1578] Fix: AnonymousUser doesn't have a profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed bugs:
 
 - [CMS-1556] Fixed copy upstream not working for pages that have the same slug but exist under different apps
+- [CMS-1578] Fixed issue with `SSORedirectUsersToRequestAccessViews` middleware that caused an `AttributeError` to be raised when a users was not authenticated
 
 
 **Implemented enhancements:**

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -14,7 +14,6 @@ class SSORedirectUsersToRequestAccessViews:
     def process_request(self, request):
 
         user = request.user
-        profile = user.userprofile
 
         if not user.is_authenticated() or user.is_superuser:
             # allow the view to handle these
@@ -28,6 +27,8 @@ class SSORedirectUsersToRequestAccessViews:
         for url in self.ignore_admin_urls:
             if request.path == str(url):
                 return
+
+        profile = user.userprofile
 
         if profile.assignment_status == UserProfile.STATUS_CREATED:
             return redirect('wagtailusers_users:sso_request_access')

--- a/users/tests/test_middleware.py
+++ b/users/tests/test_middleware.py
@@ -1,6 +1,7 @@
 import pytest
 
 from django.urls import reverse
+from django.contrib.auth.models import AnonymousUser
 
 from users.models import UserProfile
 from users.middleware import SSORedirectUsersToRequestAccessViews
@@ -16,7 +17,7 @@ class MockProfile:
 class MockUser:
     def __init__(
         self, authenticated=False, superuser=False,
-        assignment_status=None
+        assignment_status=None,
     ):
         self.authenticated = authenticated
         self.is_superuser = superuser
@@ -28,14 +29,14 @@ class MockUser:
 
 def test_process_request_returns_none_if_user_is_not_authenticated(rf):
     request = rf.get('/admin/')
-    request.user = MockUser(authenticated=False)
+    request.user = AnonymousUser()
     result = SSORedirectUsersToRequestAccessViews().process_request(request)
     assert result is None
 
 
 def test_process_request_returns_none_if_user_is_a_superuser(rf):
     request = rf.get('/admin/')
-    request.user = MockUser(authenticated=True, superuser=True)
+    request.user = MockUser(authenticated=True)
     result = SSORedirectUsersToRequestAccessViews().process_request(request)
     assert result is None
 


### PR DESCRIPTION
Updated Middleware to only attempt to find `user.profile` if the user is authenticated, and test with an `AnonymousUser` object. 