### PR TITLE
Tree based breadcrumbs serialize breadcrumbs label to be title if lab…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - No ticket - Add featured industries to Invest home page
 - CI-321 - About UK landing page
 - CI-276 - Added `CapitalInvestContactFormPage` and `CapitalInvestContactFormSuccessPage`
+- CI-429 - Tree based breadcrumbs can now use `breadcrumbs_label` if available 
 
 ### Fixed Bugs
 - CI-426 - Added pdf document upload to why choose uk page for ebook section

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -10,6 +10,11 @@ class PageTitleAndUrlSerializer(serializers.Serializer):
     url = serializers.CharField()
 
 
+class PageBreadcrumbsAndUrlSerializer(serializers.Serializer):
+    title = serializers.CharField(source='breadcrumbs_label')
+    url = serializers.CharField()
+
+
 class BasePageSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     seo_title = serializers.CharField()
@@ -27,7 +32,15 @@ class BasePageSerializer(serializers.Serializer):
         breadcrumbs = [
             page.specific for page in instance.specific.ancestors_in_app]
         breadcrumbs.append(instance)
-        return PageTitleAndUrlSerializer(breadcrumbs, many=True).data
+        serialized = []
+
+        for crumb in breadcrumbs:
+            if hasattr(crumb, 'breadcrumbs_label'):
+                serialized.append(PageBreadcrumbsAndUrlSerializer(crumb).data)
+            else:
+                serialized.append(PageTitleAndUrlSerializer(crumb).data)
+
+        return serialized
 
     def get_page_type(self, instance):
         return instance.__class__.__name__

--- a/tests/core/test_serializers.py
+++ b/tests/core/test_serializers.py
@@ -1,5 +1,8 @@
 import pytest
 from find_a_supplier.serializers import IndustryPageSerializer
+from great_international.serializers import CapitalInvestContactFormSuccessPageSerializer
+from tests.great_international.factories import CapitalInvestContactFormPageFactory, \
+    CapitalInvestContactFormSuccessPageFactory
 
 
 @pytest.mark.django_db
@@ -21,3 +24,29 @@ def test_base_page_serializer(page, rf):
     assert serializer.data['last_published_at'] == page.last_published_at
     assert serializer.data['title'] == page.title
     assert serializer.data['page_type'] == 'IndustryPage'
+
+
+@pytest.mark.django_db
+def test_tree_based_breadcrumbs_for_base_page_serializer(
+        rf, international_root_page
+):
+    form_page = CapitalInvestContactFormPageFactory(
+        slug='contact',
+        title_en_gb='form-title',
+        breadcrumbs_label='breadcrumbs',
+        parent=international_root_page
+    )
+
+    success_page = CapitalInvestContactFormSuccessPageFactory(
+        slug='success',
+        title_en_gb="success-title",
+        parent=form_page
+    )
+
+    success_serializer = CapitalInvestContactFormSuccessPageSerializer(
+        instance=success_page,
+        context={'request': rf.get('/')}
+    )
+
+    assert success_serializer.data['tree_based_breadcrumbs'][0]['title'] == 'breadcrumbs'
+    assert success_serializer.data['tree_based_breadcrumbs'][1]['title'] == 'success-title'

--- a/tests/great_international/factories.py
+++ b/tests/great_international/factories.py
@@ -738,3 +738,33 @@ class AboutUkWhyChooseTheUkPageFactory(
     title_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
     last_published_at = timezone.now()
     parent = None
+
+
+class CapitalInvestContactFormPageFactory(
+    wagtail_factories.PageFactory
+):
+
+    class Meta:
+        model = models.capital_invest.CapitalInvestContactFormPage
+
+    heading = factory.fuzzy.FuzzyText(length=50)
+    intro = factory.fuzzy.FuzzyText(length=50)
+    cta_text = factory.fuzzy.FuzzyText(length=50)
+    slug = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    title_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    last_published_at = timezone.now()
+    parent = None
+
+
+class CapitalInvestContactFormSuccessPageFactory(
+    wagtail_factories.PageFactory
+):
+
+    class Meta:
+        model = models.capital_invest.CapitalInvestContactFormSuccessPage
+
+    large_text = factory.fuzzy.FuzzyText(length=50)
+    slug = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    title_en_gb = factory.Sequence(lambda n: '123-555-{0}'.format(n))
+    last_published_at = timezone.now()
+    parent = None


### PR DESCRIPTION
…el given

Not a breaking change as serializing `breadcrumbs_label` as `title` so still works with `cms_breadcrumbs`. 

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
