### PR TITLE
Why choose the UK page can add international article page as child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - CI-460 - Added updated fields to Capital invest contact form and success pages
 - CI-475 - Added featured description to About DIT services page to be used on featured cards
 - CI-476 - Allow invest regions pages to be added as related regions to About UK pages
+- CI-477 - Why choose the UK page can add international article page as child
 
 ## [2019.08.27_1](https://github.com/uktrade/directory-cms/releases/tag/2019.08.27_1)
 [Full Changelog](https://github.com/uktrade/directory-cms/compare/2019.08.27...2019.08.27_1)

--- a/great_international/models/great_international.py
+++ b/great_international/models/great_international.py
@@ -786,7 +786,8 @@ class InternationalArticlePage(panels.InternationalArticlePagePanels, BaseIntern
         'great_international.InternationalCampaignPage',
         'great_international.InternationalCuratedTopicLandingPage',
         'great_international.InternationalGuideLandingPage',
-        'great_international.InternationalSectorPage'
+        'great_international.InternationalSectorPage',
+        'great_international.AboutUkWhyChooseTheUkPage'
     ]
     subpage_types = []
 
@@ -1867,6 +1868,7 @@ class AboutUkArticlesFields(Orderable, AboutUkArticleField):
 
 class AboutUkWhyChooseTheUkPage(panels.AboutUkWhyChooseTheUkPagePanels, BaseInternationalPage):
     parent_page_types = ['great_international.AboutUkLandingPage']
+    subpage_types = ['great_international.InternationalArticlePage']
 
     breadcrumbs_label = models.CharField(max_length=255)
     hero_title = models.CharField(max_length=255)

--- a/tests/great_international/test_models.py
+++ b/tests/great_international/test_models.py
@@ -96,6 +96,9 @@ def test_models_hierarchy():
             great_international.AboutUkRegionPage
         ]
     assert great_international.AboutUkRegionPage.allowed_subpage_models() == []
+    assert great_international.AboutUkWhyChooseTheUkPage.allowed_subpage_models() == [
+        great_international.InternationalArticlePage
+    ]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
