### PR TITLE
Xot 1185 remove market name prefix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": ".venv/bin/python3.6"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": ".venv/bin/python3.6"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- XOT-1185 - add serialized field for UI to order countries prefixed with 'the' alphabetically by country, without changing the display name
 - No ticket - Add SOO homepage
 - XOT-1177 - Upgrade Wagtail to 2.6.3
 - XOT-1170 - Remove old fields from domestic homepage

--- a/export_readiness/serializers.py
+++ b/export_readiness/serializers.py
@@ -504,6 +504,10 @@ class ChildCountryGuidePageSerializer(BasePageSerializer):
     hero_image_thumbnail = wagtail_fields.ImageRenditionField('fill-640x360', source='hero_image')
     heading = serializers.CharField()
     sub_heading = serializers.CharField()
+    sorted_title = serializers.SerializerMethodField()
+
+    def get_sorted_title(self, parent):
+        return parent.title.lower().replace('the ', '')
 
 
 class TopicLandingPageSerializer(BasePageSerializer, ChildPagesSerializerHelper, HeroSerializer):

--- a/export_readiness/serializers.py
+++ b/export_readiness/serializers.py
@@ -15,6 +15,8 @@ from .models import (
     ArticleListingPage, ArticlePage, CampaignPage, SuperregionPage, EUExitDomesticFormPage, CountryGuidePage
 )
 
+import re
+
 
 class RelatedArticlePageSerializer(BasePageSerializer):
     """Separate serializer for related article pages so we don't end up with
@@ -507,7 +509,7 @@ class ChildCountryGuidePageSerializer(BasePageSerializer):
     sorted_title = serializers.SerializerMethodField()
 
     def get_sorted_title(self, parent):
-        return parent.title.lower().replace('the ', '')
+        return re.sub(r'^the ', '', parent.title, flags=re.IGNORECASE)
 
 
 class TopicLandingPageSerializer(BasePageSerializer, ChildPagesSerializerHelper, HeroSerializer):

--- a/tests/export_readiness/test_serializers.py
+++ b/tests/export_readiness/test_serializers.py
@@ -113,8 +113,8 @@ def test_markets_page_serializer(root_page, rf):
         context={'request': rf.get('/')}
     )
 
-    sorted = serializer.data['sorted_title']
-    assert sorted == 'Netherlands'
+    cleaned_title = serializer.data['sorted_title']
+    assert cleaned_title == 'Netherlands'
 
 
 @pytest.mark.django_db

--- a/tests/export_readiness/test_serializers.py
+++ b/tests/export_readiness/test_serializers.py
@@ -114,7 +114,6 @@ def test_markets_page_serializer(root_page, rf):
     )
 
     sorted = serializer.data['sorted_title']
-    print(serializer.data)
     assert sorted == 'Netherlands'
 
 

--- a/tests/export_readiness/test_serializers.py
+++ b/tests/export_readiness/test_serializers.py
@@ -1,7 +1,7 @@
 import pytest
 from export_readiness.serializers import (
     ArticlePageSerializer, CountryGuidePageSerializer, CampaignPageSerializer, TopicLandingPageSerializer,
-    MarketingArticlePageSerializer, SellingOnlineOverseasHomePageSerializer
+    MarketingArticlePageSerializer, SellingOnlineOverseasHomePageSerializer, ChildCountryGuidePageSerializer
 )
 from tests.export_readiness.factories import (
     ArticlePageFactory, ArticleListingPageFactory, CountryGuidePageFactory, CampaignPageFactory,
@@ -92,6 +92,30 @@ def test_country_guide_page_serializer(root_page, rf):
     )
 
     assert len(serializer.data['intro_ctas']) == 0
+
+
+@pytest.mark.django_db
+def test_markets_page_serializer(root_page, rf):
+    home_page = HomePageFactory(parent=root_page)
+    markets_page = TopicLandingPageFactory(
+        title_en_gb='The Netherlands',
+        title='The Netherlands',
+        slug='topic',
+        parent=home_page)
+    country_guide = CountryGuidePageFactory(
+        title_en_gb='The Netherlands',
+        title='The Netherlands',
+        slug='country',
+        parent=markets_page)
+
+    serializer = ChildCountryGuidePageSerializer(
+        instance=country_guide,
+        context={'request': rf.get('/')}
+    )
+
+    sorted = serializer.data['sorted_title']
+    print(serializer.data)
+    assert sorted == 'Netherlands'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
…th 'the' alphabetically by country, without changing the display name

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
