### PR TITLE
Expedite non-success response during cache miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Implemented enhancements
 ## Fixed bugs
 - No ticket - Upgraded dependencies to fix security vulnerability
-
+- No ticket - Expedite non-success response during cache miss
 
 ## [2020.05.26](https://github.com/uktrade/directory-cms/releases/tag/2020.05.26)
 [Full Changelog](https://github.com/uktrade/directory-cms/compare/2020.04.22...2020.05.26)

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -1,6 +1,7 @@
 from num2words import num2words
 import copy
 import os
+import signal
 from urllib.parse import urljoin
 
 import bleach
@@ -245,3 +246,19 @@ def get_page_full_url(domain, full_path):
 
 def num2words_list(length):
     return list(map(num2words, list(range(1, length + 1))))
+
+
+class timeout:
+    def __init__(self, seconds=2, error_class=TimeoutError):
+        self.seconds = seconds
+        self.error_class = error_class
+
+    def handle_timeout(self, signum, frame):
+        raise self.error_class
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -1,13 +1,16 @@
-import pytest
+import time
+from unittest import mock
 
 from bs4 import BeautifulSoup
 from directory_constants import cms
 from modeltranslation.utils import build_localized_fieldname
+import pytest
+from rest_framework.serializers import Serializer
 
 from django.forms.models import model_to_dict
 from django.urls import reverse
 
-from core import cache, helpers, permissions, views
+from core import cache, helpers, permissions, serializer_mapping, views
 from core.helpers import CachedResponse
 from conf.signature import SignatureCheckPermission
 from components.models import ComponentsApp
@@ -229,7 +232,6 @@ def test_upstream_anon(client, translated_page, image, url_name):
 def test_add_page_prepopulate(
     is_edit, expected_template, international_root_page, translated_page, admin_client, image, cluster_data
 ):
-
     cache.PageIDCache.populate()
     url = reverse('preload-add-page')
     model_as_dict = model_to_dict(translated_page, exclude=[
@@ -451,6 +453,28 @@ def test_cache_etags_match(admin_client, international_root_page):
     )
     assert response_three.status_code == 304
     assert response_three.content == b''
+
+
+@pytest.mark.django_db
+def test_cache_miss_slow_database_read(admin_client, international_root_page):
+
+    class SlowSerializer(Serializer):
+        def to_representation(self, instance):
+            time.sleep(3)
+            return {}
+
+    service_name = cms.GREAT_INTERNATIONAL
+
+    page = InternationalSectorPageFactory.create(parent=international_root_page, live=True)
+
+    url = reverse('api:lookup-by-slug', kwargs={'slug': page.slug})
+
+    # given the page  is very slow to read
+    with mock.patch.dict(serializer_mapping.MODELS_SERIALIZERS_MAPPING, {page.__class__: SlowSerializer}):
+        response = admin_client.get(url, {'service_name': service_name})
+
+    # then the response results in 501
+    assert response.status_code == 501
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 