### PR TITLE
GBAU-927: Add a deny-all robots.txt file to the CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- GBAU-927 - Add robots.txt, disallowing everything
 - GBAU-887 - Send MarketingArticlePages to ActivityStream so they appear in search results
 - GAA-31 - Upgrading wagtail to 2.10
 - no-ticket - migrate to codecov remove coveralls

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -1,3 +1,6 @@
+
+import directory_components.views
+from directory_components.decorators import skip_ga360
 import directory_healthcheck.views
 from django.contrib import admin
 from wagtail.admin import urls as wagtailadmin_urls
@@ -84,6 +87,11 @@ urlpatterns = [
     url(
         r'^healthcheck/',
         include((healthcheck_urls, 'healthcheck'))
+    ),
+    url(
+        r"^robots\.txt$",
+        skip_ga360(directory_components.views.RobotsView.as_view(template_name='core/robots.txt')),
+        name='robots'
     ),
     url(
         r'^$',

--- a/core/templates/core/robots.txt
+++ b/core/templates/core/robots.txt
@@ -1,0 +1,2 @@
+User-agent: * 
+Disallow: /

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -519,3 +519,9 @@ def test_pages_types_view(admin_client):
 def test_pages_view(admin_client):
     response = admin_client.get('/api/pages/')
     assert response.status_code == 200
+
+
+def test_robots_txt(client):
+    response = client.get('/robots.txt')
+    assert response.content == b'User-agent: * \nDisallow: /'
+    assert response._headers['content-type'] == ('Content-Type', 'text/plain')


### PR DESCRIPTION
This changeset adds a robots.txt file to the CMS, denying /

Rendered pages already contain `noindex` meta tags but this should help with non-HTML views (eg uploaded documents linked to from published pages) being indexed against the headless CMS instead of the frontend site.

<img width="542" alt="Screenshot 2021-03-15 at 16 44 19" src="https://user-images.githubusercontent.com/101457/111189341-e3a4d900-85ad-11eb-9028-d2f7929bce51.png">



 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
