### PR TITLE
NOTICKET: Fix failing PutObject call from Wagtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre-release
 ### Implemented enhancements
+- NOTICKET: Fix failing PutObject call from Wagtail
 - GP2-3157: Add new InvestmentAtlasLandingPage model to to CMS, incl serializer
 - GP2-3153: Add new Opportunity detail page to CMS, incl serializer
 - GP2-3154: Add new Opportunity listing page to CMS, incl serializer

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -364,7 +364,7 @@ COPY_DESTINATION_URLS = env.list('COPY_DESTINATION_URLS')
 
 # django-storages
 AWS_STORAGE_BUCKET_NAME = env.str('AWS_STORAGE_BUCKET_NAME', '')
-AWS_DEFAULT_ACL = 'public-read'
+AWS_DEFAULT_ACL = None
 AWS_AUTO_CREATE_BUCKET = False
 AWS_QUERYSTRING_AUTH = False
 AWS_S3_ENCRYPTION = False
@@ -373,7 +373,7 @@ AWS_S3_CUSTOM_DOMAIN = env.str('AWS_S3_CUSTOM_DOMAIN', '')
 WS_S3_URL_PROTOCOL = env.str('AWS_S3_URL_PROTOCOL', 'https:')
 AWS_ACCESS_KEY_ID = env.str('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = env.str('AWS_SECRET_ACCESS_KEY')
-AWS_S3_HOST = 's3-us-west-1.amazonaws.com'
+AWS_S3_HOST = env.str('AWS_S3_HOST', 's3-eu-west-2.amazonaws.com')  # NB this USED to be 's3-us-west-1.amazonaws.com'
 
 # Email and notifications
 EMAIL_BACKED_CLASSES = {


### PR DESCRIPTION
This is the result of a pairing discussion to work out why Wagtail couldn't generate thumbnails, because it was being denied (403) for PutObject

Changes kept to a minimum

 - [X] Changelog entry added.
