### PR TITLE
Amended full url for Atlas homepage and opportunities listing page

### DIFF
--- a/great_international/models/investment_atlas.py
+++ b/great_international/models/investment_atlas.py
@@ -97,6 +97,12 @@ class InvestmentAtlasLandingPage(
         blank=True,
     )
 
+    @property
+    def full_url(self):
+        full_url_items = super().full_url.split('/')
+        full_url_items.remove('content')
+        return '/'.join(full_url_items)
+
 
 class InvestmentOpportunityListingPage(
     WagtailAdminExclusivePageMixin,
@@ -127,6 +133,12 @@ class InvestmentOpportunityListingPage(
     contact_cta_link = models.URLField(
         blank=True,
     )
+
+    @property
+    def full_url(self):
+        full_url_items = super().full_url.split('/')
+        full_url_items.remove('content')
+        return '/'.join(full_url_items)
 
 
 class RelatedSector(models.Model):


### PR DESCRIPTION
This changeset amends URL fields in the serializer. These homepage doesn't needs to have content in url and have their own standalone page. 