### PR TITLE
GP2-3330: Extend InvestmentOpportunityForListPageSerializer to guarantee representation of PlanningStatus snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre-release
 ### Implemented enhancements
+- GP2-3330: Extend InvestmentOpportunityForListPageSerializer to guarantee representation of PlanningStatus snippet
 - GP2-3330: Extend PlanningStatus snippet model field to support a verbose description
 - GP2-3157: (Extension): Refactor the InvestmentOpportunity page in light of new designs
 - NOTICKET: Fix failing PutObject call from Wagtail

--- a/great_international/serializers.py
+++ b/great_international/serializers.py
@@ -2744,7 +2744,7 @@ class InvestmentOpportunityForListPageSerializer(BasePageSerializer):
 
     scale = serializers.CharField(max_length=255)
     scale_value = serializers.DecimalField(max_digits=10, decimal_places=2)
-    planning_status = serializers.CharField(max_length=255)
+    planning_status = serializers.SerializerMethodField()
     investment_type = serializers.CharField(max_length=255)
     time_to_investment_decision = serializers.SerializerMethodField()
 
@@ -2761,6 +2761,11 @@ class InvestmentOpportunityForListPageSerializer(BasePageSerializer):
                 value=first_image.value,
                 context={'rendition_spec': rendition_spec}
             )
+
+    def get_planning_status(self, instance):
+        # Ensure we always return the name, not the entire object. This protects against
+        # the __str__ method being changed and breaking things
+        return instance.planning_status.name
 
     def get_time_to_investment_decision(self, instance):
         return instance.get_time_to_investment_decision_display()

--- a/tests/great_international/test_models.py
+++ b/tests/great_international/test_models.py
@@ -150,3 +150,15 @@ def test_url_for_investment_atlas_landing_page(international_root_page):
         parent=int_home
     )
     assert 'content' not in invest_home.url.split('/')
+
+
+@pytest.mark.django_db
+def test_planning_status__str__method():
+    # Just to keep coverage happy...
+
+    planning_status = factories.PlanningStatusFactory(
+        name="Planning Status One",
+        verbose_description="Verbose description for the first planning status type"
+    )
+
+    assert f"{planning_status}" == "Planning Status One"

--- a/tests/great_international/test_serializers.py
+++ b/tests/great_international/test_serializers.py
@@ -2128,7 +2128,7 @@ def test_atlas_related_investment_opportunity_page_serializer__get_thumbnail_ima
 
 
 @pytest.mark.django_db
-def test_atlas_opportunity_listing_page_serializer__get_planning_status(
+def test_atlas_opportunity_page_serializer__get_planning_status(
     rf,
     international_root_page,
 ):
@@ -2137,7 +2137,6 @@ def test_atlas_opportunity_listing_page_serializer__get_planning_status(
         name="Planning Status One",
         verbose_description="Verbose description for the first planning status type"
     )
-
     opportunity = InvestmentOpportunityPageFactory(
         parent=international_root_page,
         slug='opp_one',
@@ -2154,7 +2153,7 @@ def test_atlas_opportunity_listing_page_serializer__get_planning_status(
 
 
 @pytest.mark.django_db
-def test_atlas_opportunity_listing_page_serializer__get_planning_status__is_null(
+def test_atlas_opportunity_page_serializer__get_planning_status__is_null(
     rf,
     international_root_page,
 ):
@@ -2169,3 +2168,24 @@ def test_atlas_opportunity_listing_page_serializer__get_planning_status__is_null
         context={'request': rf.get('/')}
     )
     assert opportunity_serializer.data['planning_status'] == dict()
+
+
+@pytest.mark.django_db
+def test_atlas_opportunity_listing_page_serializer__planning_status__is_not_verbose(
+    international_root_page,
+):
+
+    planning_status = PlanningStatusFactory(
+        name="Planning Status One",
+        verbose_description="Verbose description for the first planning status type"
+    )
+    opportunity = InvestmentOpportunityPageFactory(
+        parent=international_root_page,
+        slug='opp_one',
+        planning_status=planning_status,
+    )
+
+    opportunity_for_list_serializer = InvestmentOpportunityForListPageSerializer(
+        instance=opportunity
+    )
+    assert opportunity_for_list_serializer.data['planning_status'] == 'Planning Status One'


### PR DESCRIPTION
By default, the serializers.CharField was using the string method of the FKed PlanningStatus record to get its name. This worked, but would break things if that __str__() method was changed.

This changeset makes things stable by explicitly stating what to use for the planning-status name when listing opportunities.

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
