### PR TITLE
GP2-3287:  Add 'related opportunities' to the data available for a Region page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre-release
 ### Implemented enhancements
+- GP2-3287: Add Related Opportunities to the region-page's serializer
 - GP2-3158: REVIST Refactor of InternationalHomepage on the CMS side -- had to make a simpler version after reverting previous branch, because migrations timed out
 - GP2-3158: Refactor InternationalHomepage on the CMS side (Page, translations, serializer)
 - GP2-3330: Extend InvestmentOpportunityForListPageSerializer to guarantee representation of PlanningStatus snippet


### PR DESCRIPTION
This changeset expands (but does not otherwise amend) the API representation of a Region page, so that it includes up to three serializes Investment Opportunities in its response. (ie, the Opps are Atlas ones, not the old CapInvest type)

To be selected, an InvestmentOpportunity must have the current region as one of their related regions. They are then sorted by priority_weighting, if set, and then use their PK as a secondary sorting key. This means that highly weighted ones appear first, then any ties are broken by using the most recently created (ie highest PK) opp first.

In total up to three opps are included, but 0..3 is possible.

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
