### PR TITLE
Allowing regions listing page to be under InvestmentAtlas Homepage

### DIFF
--- a/great_international/models/great_international.py
+++ b/great_international/models/great_international.py
@@ -945,7 +945,9 @@ class InternationalCampaignPage(panels.InternationalCampaignPagePanels, BaseInte
 class InternationalTopicLandingPage(panels.InternationalTopicLandingPagePanels, BaseInternationalPage):
     parent_page_types = [
         'great_international.InternationalHomePage',
-        'great_international.AboutUkLandingPage'
+        'great_international.AboutUkLandingPage',
+        'great_international.InvestmentAtlasLandingPage'
+
     ]
     subpage_types = [
         'great_international.InternationalArticleListingPage',
@@ -1545,7 +1547,7 @@ class AboutUkRegionListingPage(
         'great_international.InvestmentAtlasLandingPage'
     ]
     subpage_types = [
-        'great_international.AboutUkRegionListingPage',
+        'great_international.AboutUkRegionPage',
     ]
 
     breadcrumbs_label = models.CharField(max_length=255)

--- a/great_international/models/great_international.py
+++ b/great_international/models/great_international.py
@@ -1540,9 +1540,12 @@ class AboutUkRegionListingPage(
 
     slug_identity = 'regions'
 
-    parent_page_types = ['great_international.AboutUkLandingPage']
+    parent_page_types = [
+        'great_international.AboutUkLandingPage',
+        'great_international.InvestmentAtlasLandingPage'
+    ]
     subpage_types = [
-        'great_international.AboutUkRegionPage',
+        'great_international.AboutUkRegionListingPage',
     ]
 
     breadcrumbs_label = models.CharField(max_length=255)

--- a/great_international/models/investment_atlas.py
+++ b/great_international/models/investment_atlas.py
@@ -121,7 +121,7 @@ class InvestmentAtlasLandingPage(
         # TO COME: more subpage_types to control CMS page heirarchy
         'great_international.AboutUkWhyChooseTheUkPage',
         'great_international.AboutUkRegionListingPage',
-
+        'great_international.InternationalTopicLandingPage',
     ]
 
     # title comes from base page

--- a/great_international/models/investment_atlas.py
+++ b/great_international/models/investment_atlas.py
@@ -120,6 +120,7 @@ class InvestmentAtlasLandingPage(
         'great_international.InvestmentOpportunityListingPage',
         # TO COME: more subpage_types to control CMS page heirarchy
         'great_international.AboutUkWhyChooseTheUkPage',
+        'great_international.AboutUkRegionListingPage',
 
     ]
 


### PR DESCRIPTION
Allowing regions and Industries pages to be children of InvestmentAtlasHomepage

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog has entry regarding this changes so no new entry added
