### PR TITLE
GP2-3394: Fix InternalOrExternalLinkBlock's url generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre-release
 ### Implemented enhancements
+- GP2-3394: Fix InternalOrExternalLinkBlock's url generation
 - GP2-3398: Add AboutUKRegionPage.region_summary_section_strapline field
 - GP2-3374: Refactor WhyInvestUK page
 - GP2-3400: Backend for new How We Can Help page, via generic content page

--- a/core/blocks.py
+++ b/core/blocks.py
@@ -61,7 +61,7 @@ class InternalOrExternalLinkBlock(blocks.StructBlock):
             isinstance(original_retval_dict['internal_link'], int)
         ):
             # Correct this to be a full URL, not a page ID
-            retval = value['internal_link'].get_url()
+            retval = value['internal_link'].specific.get_url()  # Note, this lacks the port number when used locally
         elif 'external_link' in original_retval_dict:
             retval = value['external_link']
 

--- a/tests/great_international/test_models.py
+++ b/tests/great_international/test_models.py
@@ -132,24 +132,29 @@ def test_hpo_folder_page(international_root_page):
 
 @pytest.mark.django_db
 def test_url_for_investment_opportunity_listing_page(international_root_page):
-    int_home = factories.InternationalHomePageFactory(
-        parent=international_root_page
+    atlas_home = factories.InvestmentAtlasLandingPageFactory(
+        parent=international_root_page,
+        slug='investment',
     )
-    invest_home = factories.InvestmentOpportunityListingPageFactory(
-        parent=int_home
+    opportunities = factories.InvestmentOpportunityListingPageFactory(
+        parent=atlas_home,
+        slug='opportunities',
     )
-    assert 'content' not in invest_home.url.split('/')
+
+    assert 'content' not in opportunities.url.split('/')
+    assert opportunities.get_url() == 'http://great.gov.uk/international/investment/opportunities/'
+    assert opportunities.url == 'http://great.gov.uk/international/investment/opportunities/'
 
 
 @pytest.mark.django_db
 def test_url_for_investment_atlas_landing_page(international_root_page):
-    int_home = factories.InternationalHomePageFactory(
-        parent=international_root_page
+    atlas_home = factories.InvestmentAtlasLandingPageFactory(
+        parent=international_root_page,
+        slug='investment',
     )
-    invest_home = factories.InvestmentAtlasLandingPageFactory(
-        parent=int_home
-    )
-    assert 'content' not in invest_home.url.split('/')
+    assert 'content' not in atlas_home.url.split('/')
+    assert atlas_home.get_url() == 'http://great.gov.uk/international/investment/'
+    assert atlas_home.url == 'http://great.gov.uk/international/investment/'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Because we weren't using .specific to get the subclass, we weren't benefitting from the correct URL generation

Note, however, that the Page.get_url() does not seem to include the port number when used locally - that's a separate issue but won't affect deployed versions of the site

Also, the international homepage will need re-publishing to refresh the cache with updated data.

To do (delete all that do not apply):

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
