### PR TITLE
NOTICKET: add opportunity_summary to opp listing page results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 ### Implemented enhancements
 - GP2-3394: Fix InternalOrExternalLinkBlock's url generation
+- NOTICKET: add opportunity_summary to opp listing page results
 - GP2-3398: Add AboutUKRegionPage.region_summary_section_strapline field
 - GP2-3374: Refactor WhyInvestUK page
 - GP2-3400: Backend for new How We Can Help page, via generic content page

--- a/great_international/serializers.py
+++ b/great_international/serializers.py
@@ -2303,7 +2303,6 @@ class InvestmentOpportunityPageSerializer(BasePageSerializer):
     breadcrumbs_label = serializers.CharField()
     strapline = serializers.CharField()
     introduction = core_fields.MarkdownToHTMLField()
-    opportunity_summary = serializers.CharField()
     hero_image = wagtail_fields.ImageRenditionField(
         HERO_IMAGE_RENDITION_SPEC,
     )
@@ -2463,6 +2462,7 @@ class InvestmentOpportunityForListPageSerializer(BasePageSerializer):
     )
     # key facts we want to filter by
     # sector = serializers.CharField(max_length=255)  # doesn't exist on new opp model [yet?]
+    opportunity_summary = serializers.CharField()
 
     scale = serializers.CharField(max_length=255)
     scale_value = serializers.DecimalField(max_digits=10, decimal_places=2)


### PR DESCRIPTION

* Removes `opportunity_summary` from the opportunity detail page, because it's not intended for use on the detail page itself
* Adds `opportunity_summary` to the serializer that lists opportunities for the list/search results page, where it IS appropriate

 - [X] Changelog entry added.
