### PR TITLE
NOTICKET: Rename serializer to avoid name clash/redefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre-release
 ### Implemented enhancements
+- NOTICKET: Rename serializer to avoid name clash/redefinition
 - NOTICKET: Increase length of case study text field on region page (255 to 500 chars)
 - NOTICKET: Add help text to the streamfield text blocks that use a markdown HR as expander toggle
 - NOTICKET: Added HeroSerializer for InvestmentOpportunityPageSerializer to align with other page

--- a/great_international/serializers.py
+++ b/great_international/serializers.py
@@ -607,7 +607,7 @@ class RelatedAboutUkRegionPageSerializer(BasePageSerializer):
     featured_description = serializers.CharField()
 
 
-class RelatedInvestmentOpportunityPageSerializer(BasePageSerializer):
+class RelatedInvestmentOpportunityPageMinimalSerializer(BasePageSerializer):
     title = serializers.CharField()
     hero_image = wagtail_fields.ImageRenditionField('fill-640x360')
     featured_description = serializers.CharField(source='strapline')
@@ -638,7 +638,7 @@ MODEL_TO_SERIALIZER_MAPPING = {
     WhyInvestInTheUKPage: RelatedWhyInvestInTheUKPageSerializer,
     InternationalTopicLandingPage: RelatedInternationalTopicLandingPageSerializer,
     AboutUkRegionPage: RelatedAboutUkRegionPageSerializer,
-    InvestmentOpportunityPage: RelatedInvestmentOpportunityPageSerializer,
+    InvestmentOpportunityPage: RelatedInvestmentOpportunityPageMinimalSerializer,
     InvestmentGeneralContentPage: RelatedInvestmentGeneralContentPageSerializer,
     AboutUkRegionListingPage: RelatedAboutUkRegionListingPageSerializer,
     InvestmentOpportunityListingPage: RelatedInvestmentOpportunityListingPageSerializer,


### PR DESCRIPTION
When pairing with Riz, we noticed we had two serializers with the same name - this changeset fixes that.

 - [X] Changelog entry added.
