### PR TITLE
GLS-193 Add simple format validator to lat/long field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 ### Implemented enhancements
 
-
-
 ### Fixed bugs
 
+- GLS-193 - prevent invalid latitude/longitude in linked location coordinates
 
 
 ## [2.3.0](https://github.com/uktrade/directory-cms/releases/tag/2.3.0)

--- a/great_international/blocks/investment_atlas.py
+++ b/great_international/blocks/investment_atlas.py
@@ -8,6 +8,7 @@ from great_international.blocks.great_international import (
     MarkdownBlock,
     InternationalInvestmentPageCopyBlockBase,
 )
+from great_international.validators import validate_lat_long
 
 
 class InlineOpportunityImageBlock(BaseAltTextImageBlock):
@@ -216,12 +217,12 @@ class OpportunityLocationBlock(blocks.StructBlock):
         required=False,
         label='Linked Region',
         page_type='great_international.AboutUkRegionPage'
-
     )
     map_coordinate = blocks.CharBlock(
         max_length=200,
         label='Linked Location Coordinates',
         help_text='Latitude and longitude Coordinates, e.g. 176.0944492, -38.50245621',
+        validators=[validate_lat_long],
     )  # deliberately not a pointfield yet
 
     def get_api_representation(self, value, context=None):

--- a/great_international/validators.py
+++ b/great_international/validators.py
@@ -1,0 +1,8 @@
+import re
+
+from django.core.exceptions import ValidationError
+
+
+def validate_lat_long(value):
+    if re.match(r'^(-|\+)?\d{1,3}(\.\d+)?\s*,\s*(-|\+)?\d{1,3}(\.\d+)?$', value.strip()) is None:
+        raise ValidationError('Invalid latitude/longitude.')

--- a/tests/great_international/test_validators.py
+++ b/tests/great_international/test_validators.py
@@ -1,0 +1,31 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from great_international.validators import validate_lat_long
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'value, raise_expected',
+    (
+        ('51.123456, -2.345678', False),
+        (' 51.123456  , -2.345678  ', False),
+        ('+51.123456, +1.1', False),
+        ('  51.123456,   -2.345678  ', False),
+        ('31.123456,2.345678', False),
+        ('50, 2', False),
+        ('50., 2.', True),
+        ('50', True),
+        ('50º N, 2º W', True),
+        ('Not even trying', True),
+    )
+)
+def test_validate_lat_long(value, raise_expected):
+    try:
+        validate_lat_long(value)
+    except ValidationError:
+        if not raise_expected:
+            pytest.fail(f'Expected {value} to pass validation, but it failed')
+    else:
+        if raise_expected:
+            pytest.fail(f'Expected {value} to fail validation, but it passed')


### PR DESCRIPTION
Prevents lat/long entry using `ºN/ºW` notation, or anything else that might not be parsed properly by the front-end.

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
