### PR TITLE
Add changelog entry for investment atlas hero CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+* GLS-316 - Add functionality to store a hero CTA title and URL for the investment atlas landing page.
 
 ### Fixed bugs
 


### PR DESCRIPTION
This PR adds a changelog entry for the addition of functionality to store a hero CTA title and URL for the investment atlas landing page - related to changes in PR #1027  .