### PR TITLE
Upgrade django-filter to 2.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-staff-sso-client==1.*
 html2text==2018.1.9
 wagtailmedia==0.*
 pytube==9.2.2
-django-filter==2.2.*
+django-filter>=2.4.0
 django-redis==4.10.0
 celery[redis]==5.2.2
 django-celery-beat==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ django-celery-beat==2.2.1
     # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
-django-filter==2.2.0
+django-filter==2.4.0
     # via
     #   -r requirements.in
     #   wagtail

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -107,7 +107,7 @@ django-debug-toolbar==3.2.4
     # via -r requirements_test.in
 django-environ==0.4.5
     # via -r requirements.in
-django-filter==2.2.0
+django-filter==2.4.0
     # via
     #   -r requirements.in
     #   wagtail


### PR DESCRIPTION
This PR reverts django-filter back to version 2.4.0.

In PR #1041 it reverted django-filter to 2.2.*, however any version less than 2.4.0 is vulnerable.
