### PR TITLE
Fix - Update whitenoise usage for 6.4.0

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -200,7 +200,7 @@ MEDIA_URL = '/media/'
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles')
 STATIC_HOST = env.str('STATIC_HOST', '')
 STATIC_URL = STATIC_HOST + '/static/'
-STATICFILES_STORAGE = env.str('STATICFILES_STORAGE', 'whitenoise.storage.CompressedManifestStaticFilesStorage')
+STATICFILES_STORAGE = env.str('STATICFILES_STORAGE', 'whitenoise.storage.CompressedStaticFilesStorage')
 DEFAULT_FILE_STORAGE = env.str('DEFAULT_FILE_STORAGE', 'core.storage_backends.ImmutableFilesS3Boto3Storage')
 
 # Logging for development

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ django-environ==0.*
 gunicorn==20.*
 sentry-sdk==1.*
 django_storages==1.13.*
-whitenoise==6.*
+whitenoise==6.4.*
 dj-database-url==2.*
 psycopg2==2.9.* --no-binary psycopg2
 django-pglocks==1.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     # via kombu
 anyascii==0.3.2
     # via wagtail
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -61,7 +61,7 @@ cron-descriptor==1.4.0
     # via django-celery-beat
 cryptography==39.0.2
     # via -r requirements.in
-directory-components==39.1.0
+directory-components==39.1.2
     # via -r requirements.in
 directory-constants==23.1.0
     # via

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     # via kombu
 anyascii==0.3.2
     # via wagtail
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -71,7 +71,7 @@ cron-descriptor==1.4.0
     # via django-celery-beat
 cryptography==39.0.2
     # via -r requirements.in
-directory-components==39.1.0
+directory-components==39.1.2
     # via -r requirements.in
 directory-constants==23.1.0
     # via


### PR DESCRIPTION
This PR updates our usage of whitenoise in settings.py to be compatible with version 6.4.0. It also specifies 6.4.* in requirements rather than 6.*.

### Workflow
- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-668
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping
- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
